### PR TITLE
Add optional Google Calendar sync for meetings

### DIFF
--- a/frontend/src/app/(protected)/events/page.jsx
+++ b/frontend/src/app/(protected)/events/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Script from "next/script";
 
 import ScheduleMeetingForm from "@/components/Events/ScheduleMeetingForm";
 import EventList from "@/components/Events/EventList";
@@ -15,6 +16,10 @@ export default function EventsPage() {
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,_#dbeafe,_transparent_35%),linear-gradient(135deg,_#f8fafc,_#eef2ff)] px-6 py-8">
+      <Script
+        src="https://accounts.google.com/gsi/client"
+        strategy="afterInteractive"
+      />
       <div className="mx-auto max-w-7xl">
         <section className="mb-8 overflow-hidden rounded-[2rem] bg-slate-950 px-8 py-9 text-white shadow-xl">
           <div className="flex flex-col justify-between gap-6 lg:flex-row lg:items-end">

--- a/frontend/src/components/Events/ScheduleMeetingForm.jsx
+++ b/frontend/src/components/Events/ScheduleMeetingForm.jsx
@@ -7,6 +7,7 @@ import { createNotifications } from "@/firebase/notificationsService";
 import { buildReminderSchedule } from "@/firebase/reminderScheduleService";
 import { updateEvent } from "@/firebase/eventsService";
 import { deleteNotificationsByEventId } from "@/firebase/notificationsService";
+import { createGoogleCalendarEvent } from "@/firebase/googleCalendarService";
 
 
 export default function ScheduleMeetingForm({
@@ -32,6 +33,8 @@ export default function ScheduleMeetingForm({
 
   const [loading, setLoading] = useState(false);
   const [formError, setFormError] = useState("");
+  const [syncToGoogle, setSyncToGoogle] = useState(false);
+  const [syncWarning, setSyncWarning] = useState("");
 
   const inputClass =
     "w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-blue-500 focus:bg-white focus:ring-4 focus:ring-blue-100";
@@ -168,6 +171,37 @@ export default function ScheduleMeetingForm({
       );
   
       await createNotifications(reminders);
+      // Optional Google Calendar sync (non-blocking for meeting creation)
+      if (syncToGoogle) {
+        try {
+          // provide local id for extendedProperties in Google event
+          eventPayload.id = eventId;
+
+          const googleEvent = await createGoogleCalendarEvent(eventPayload);
+
+          // update Firestore event with Google sync metadata
+          await updateEvent(eventId, {
+            googleCalendarEventId: googleEvent?.id || null,
+            googleCalendarLink: googleEvent?.htmlLink || googleEvent?.hangoutLink || null,
+            calendarSyncStatus: "synced",
+            calendarSyncLabel: "Synced to Google Calendar",
+          });
+        } catch (err) {
+          // Do not block meeting creation — mark sync as failed and show a warning
+          try {
+            await updateEvent(eventId, {
+              calendarSyncStatus: "failed",
+              calendarSyncLabel: "Failed to sync to Google Calendar",
+            });
+          } catch {
+            // Ignore Firestore sync status update failure
+          }
+
+          setSyncWarning(
+            err?.message || "Failed to sync meeting to Google Calendar.",
+          );
+        }
+      }
   
       if (onMeetingCreated) {
         onMeetingCreated();
@@ -212,6 +246,12 @@ export default function ScheduleMeetingForm({
         {formError && (
           <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
             {formError}
+          </div>
+        )}
+
+        {syncWarning && (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-800">
+            {syncWarning}
           </div>
         )}
 
@@ -365,6 +405,19 @@ export default function ScheduleMeetingForm({
             </div>
           </div>
         )}
+
+        <div>
+          <label className="mb-2 inline-flex items-center gap-3 text-sm font-bold text-slate-700">
+            <input
+              type="checkbox"
+              name="syncToGoogle"
+              checked={syncToGoogle}
+              onChange={(e) => setSyncToGoogle(e.target.checked)}
+              className="h-4 w-4 rounded"
+            />
+            <span>Sync to Google Calendar</span>
+          </label>
+        </div>
 
        <button
           type="submit"

--- a/frontend/src/firebase/googleCalendarService.js
+++ b/frontend/src/firebase/googleCalendarService.js
@@ -1,0 +1,220 @@
+// Browser-side Google Calendar service using Google Identity Services
+// Exports: createGoogleCalendarEvent, updateGoogleCalendarEvent, deleteGoogleCalendarEvent
+
+const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+const SCOPE = "https://www.googleapis.com/auth/calendar.events";
+
+let tokenClient = null;
+let accessToken = null;
+let accessTokenExpiresAt = 0;
+
+function ensureClientId() {
+  if (!CLIENT_ID) {
+    throw new Error(
+      "NEXT_PUBLIC_GOOGLE_CLIENT_ID is not set. Please add it to your environment.",
+    );
+  }
+}
+
+function ensureGisLoaded() {
+  if (typeof window === "undefined" || !window.google || !window.google.accounts || !window.google.accounts.oauth2) {
+    throw new Error(
+      "Google Identity Services not available. Make sure the GIS script (https://accounts.google.com/gsi/client) is loaded on the page.",
+    );
+  }
+}
+
+function initTokenClient() {
+  ensureClientId();
+  ensureGisLoaded();
+
+  if (!tokenClient) {
+    tokenClient = window.google.accounts.oauth2.initTokenClient({
+      client_id: CLIENT_ID,
+      scope: SCOPE,
+      callback: (tokenResponse) => {
+        if (tokenResponse && tokenResponse.access_token) {
+          accessToken = tokenResponse.access_token;
+          // tokenResponse.expires_in is seconds
+          accessTokenExpiresAt = Date.now() + (tokenResponse.expires_in ? tokenResponse.expires_in * 1000 : 55 * 60 * 1000);
+        }
+      },
+    });
+  }
+
+  return tokenClient;
+}
+
+function requestAccessTokenInteractive() {
+  return new Promise((resolve, reject) => {
+    try {
+      initTokenClient();
+
+      // If we already have a valid token, return it
+      if (accessToken && Date.now() < accessTokenExpiresAt - 5000) {
+        resolve(accessToken);
+        return;
+      }
+
+      // The token client uses a callback to populate accessToken; wrap that flow
+      const originalCallback = tokenClient.callback;
+
+      tokenClient.callback = (tokenResponse) => {
+        try {
+          if (!tokenResponse || tokenResponse.error) {
+            reject(new Error(tokenResponse && tokenResponse.error ? tokenResponse.error : "Failed to obtain access token."));
+            return;
+          }
+
+          accessToken = tokenResponse.access_token;
+          accessTokenExpiresAt = Date.now() + (tokenResponse.expires_in ? tokenResponse.expires_in * 1000 : 55 * 60 * 1000);
+          resolve(accessToken);
+        } finally {
+          // restore original callback shape for safety
+          tokenClient.callback = originalCallback;
+        }
+      };
+
+      // Request an access token. This may open a popup for user consent if needed.
+      tokenClient.requestAccessToken({ prompt: "consent" });
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
+
+async function getAccessToken() {
+  ensureClientId();
+  ensureGisLoaded();
+
+  if (accessToken && Date.now() < accessTokenExpiresAt - 5000) {
+    return accessToken;
+  }
+
+  // Request interactively; callers should be used in user-gesture contexts if needed
+  const token = await requestAccessTokenInteractive();
+  if (!token) {
+    throw new Error("Failed to obtain Google access token.");
+  }
+
+  return token;
+}
+
+function buildEventPayload(event) {
+  // event expects fields: date, time, durationMinutes (optional), title, notes, priority, clientName, reminderLabel, location
+
+  if (!event.date || !event.time) {
+    throw new Error("Missing event date or time for Google Calendar event.");
+  }
+
+  const start = new Date(`${event.date}T${event.time}`);
+
+  if (Number.isNaN(start.getTime())) {
+    throw new Error("Invalid event date/time for Google Calendar event.");
+  }
+
+  const duration = Number.isFinite(Number(event.durationMinutes)) && Number(event.durationMinutes) > 0
+    ? Number(event.durationMinutes)
+    : 60;
+
+  const end = new Date(start.getTime() + duration * 60 * 1000);
+
+  const descriptionParts = [];
+  if (event.notes) descriptionParts.push(String(event.notes));
+  if (event.clientName) descriptionParts.push(`Participant: ${event.clientName}`);
+  if (event.priority) descriptionParts.push(`Priority: ${event.priority}`);
+  if (event.reminderLabel || event.reminderOption) descriptionParts.push(`Reminder: ${event.reminderLabel || event.reminderOption}`);
+
+  const description = descriptionParts.join("\n\n");
+
+  const payload = {
+    summary: event.title || "Meeting",
+    description: description || undefined,
+    start: {
+      dateTime: start.toISOString(),
+      timeZone: "Asia/Jerusalem",
+    },
+    end: {
+      dateTime: end.toISOString(),
+      timeZone: "Asia/Jerusalem",
+    },
+  };
+
+  if (event.location) payload.location = event.location;
+
+  // Attach local metadata if available
+  if (event.id) {
+    payload.extendedProperties = {
+      private: {
+        localEventId: String(event.id),
+      },
+    };
+  }
+
+  return payload;
+}
+
+async function callGoogleCalendarApi(path, method = "GET", body = null) {
+  const token = await getAccessToken();
+
+  const url = `https://www.googleapis.com/calendar/v3/calendars/primary${path}`;
+
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : null,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google Calendar API error ${res.status}: ${text}`);
+  }
+
+  if (res.status === 204) return null;
+
+  return await res.json();
+}
+
+export async function createGoogleCalendarEvent(event) {
+  ensureClientId();
+  ensureGisLoaded();
+
+  const payload = buildEventPayload(event);
+
+  const created = await callGoogleCalendarApi(`/events`, "POST", payload);
+
+  return created; // returns Google event resource
+}
+
+export async function updateGoogleCalendarEvent(googleEventId, event) {
+  ensureClientId();
+  ensureGisLoaded();
+
+  if (!googleEventId) throw new Error("googleEventId is required to update a Google Calendar event.");
+
+  const payload = buildEventPayload(event);
+
+  const updated = await callGoogleCalendarApi(`/events/${encodeURIComponent(googleEventId)}`, "PATCH", payload);
+
+  return updated;
+}
+
+export async function deleteGoogleCalendarEvent(googleEventId) {
+  ensureClientId();
+  ensureGisLoaded();
+
+  if (!googleEventId) throw new Error("googleEventId is required to delete a Google Calendar event.");
+
+  await callGoogleCalendarApi(`/events/${encodeURIComponent(googleEventId)}`, "DELETE");
+
+  return true;
+}
+
+export default {
+  createGoogleCalendarEvent,
+  updateGoogleCalendarEvent,
+  deleteGoogleCalendarEvent,
+};


### PR DESCRIPTION
## Summary

Added optional Google Calendar synchronization for scheduled meetings.

The Events page now loads Google Identity Services only inside the Events route, without modifying the global application layout. A new `googleCalendarService.js` service was added to handle Google OAuth token retrieval and communication with the Google Calendar API.

The meeting form now includes an optional “Sync to Google Calendar” checkbox. When selected, the system first saves the meeting to Firestore using the existing event creation flow, keeps the existing reminder creation logic unchanged, and then attempts to create a matching event in Google Calendar.

If the Google Calendar sync succeeds, the Firestore event is updated with Google Calendar metadata such as the calendar event ID, calendar link, and sync status. If the sync fails, the meeting and reminder remain saved in the system, and the event is marked with a failed sync status. This keeps Google Calendar as an optional enhancement and prevents external API failures from breaking the core scheduling flow.

## Files changed

- `frontend/src/firebase/googleCalendarService.js`
  - Added Google Calendar API integration logic.
  - Handles OAuth access token retrieval using Google Identity Services.
  - Supports create, update, and delete operations for Google Calendar events.

- `frontend/src/app/(protected)/events/page.jsx`
  - Loads the Google Identity Services script only on the Events page.

- `frontend/src/components/Events/ScheduleMeetingForm.jsx`
  - Added optional Google Calendar sync checkbox.
  - Connected meeting creation to Google Calendar sync after Firestore creation.
  - Preserves existing reminder creation behavior.
  - Handles sync failure gracefully without blocking meeting creation.

## Testing

Tested locally by:
- Creating a meeting without Google Calendar sync.
- Creating a meeting with Google Calendar sync enabled.
- Confirming the meeting is saved in Firestore.
- Confirming the reminder is created in `automatic_notifications`.
- Confirming the Google Calendar event is created successfully.
- Confirming that if sync fails, the meeting still remains saved in the system.

## Environment variable required

To test Google Calendar sync locally, add the following variable to `frontend/.env.local`:

```env
NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id_here