### PR TITLE
Add Google Calendar reminder overrides

### DIFF
--- a/frontend/src/firebase/googleCalendarService.js
+++ b/frontend/src/firebase/googleCalendarService.js
@@ -151,6 +151,47 @@ function buildEventPayload(event) {
     };
   }
 
+  // Add Google Calendar reminder overrides derived from our event reminder settings.
+  try {
+    const PRESET_MINUTES = {
+      half_hour_before: 30,
+      two_hours_before: 120,
+      one_day_before: 1440,
+      three_days_before: 4320,
+      one_week_before: 10080,
+      event_time: 0,
+    };
+
+    let minutesBefore = null;
+
+    if (event.reminderMode === "custom") {
+      if (event.customReminderDate && event.customReminderTime) {
+        const scheduledFor = new Date(`${event.customReminderDate}T${event.customReminderTime}`);
+        if (!Number.isNaN(scheduledFor.getTime())) {
+          minutesBefore = Math.round((start.getTime() - scheduledFor.getTime()) / 60000);
+        }
+      }
+    } else {
+      // preset
+      minutesBefore = PRESET_MINUTES[event.reminderOption];
+    }
+
+    if (Number.isFinite(minutesBefore) && minutesBefore >= 0) {
+      payload.reminders = {
+        useDefault: false,
+        overrides: [
+          {
+            method: "popup",
+            minutes: minutesBefore,
+          },
+        ],
+      };
+    }
+  } catch (err) {
+    // If reminder conversion fails, do not break event creation/update — skip Google reminders.
+    // Intentionally swallow errors here to avoid affecting the primary flow.
+  }
+
   return payload;
 }
 


### PR DESCRIPTION
## Summary

Added Google Calendar reminder overrides based on the reminder selected in the meeting form.

Preset reminders are converted to Google Calendar popup reminders:
- 30 minutes before
- 2 hours before
- 1 day before
- 3 days before
- 1 week before
- at event time

Custom reminders are converted by calculating the number of minutes between the meeting start time and the selected custom reminder date/time.

## Notes

This change only affects the Google Calendar event payload.
Firestore reminder logic and in-system notifications remain unchanged.

## Testing

Tested by creating and editing synced meetings with preset and custom reminders, then confirming the Google Calendar event reminder matched the selected reminder.