### PR TITLE
Preserve meeting history and clean up Google Calendar lifecycle

### DIFF
--- a/frontend/src/components/Events/EventList.jsx
+++ b/frontend/src/components/Events/EventList.jsx
@@ -6,7 +6,7 @@ import {
   cancelEvent,
   completeEvent,
   deleteEvent,
-  getEvents,
+  getEventsWithinDays,
   updateEvent,
 } from "@/firebase/eventsService";
 import { deleteGoogleCalendarEvent } from "@/firebase/googleCalendarService";
@@ -31,7 +31,7 @@ export default function EventList({
   async function loadEvents() {
     try {
       setLoading(true);
-      const eventsFromDb = await getEvents();
+      const eventsFromDb = await getEventsWithinDays(2);
       setEvents(eventsFromDb);
     } catch (error) {
       console.error(error);

--- a/frontend/src/components/Events/EventList.jsx
+++ b/frontend/src/components/Events/EventList.jsx
@@ -7,7 +7,9 @@ import {
   completeEvent,
   deleteEvent,
   getEvents,
+  updateEvent,
 } from "@/firebase/eventsService";
+import { deleteGoogleCalendarEvent } from "@/firebase/googleCalendarService";
 import {
   deleteNotificationsByEventId,
   updateNotificationsByEventId,
@@ -73,13 +75,39 @@ export default function EventList({
     }
   }
 
-  async function handleCancel(eventId) {
+  async function handleCancel(event) {
     try {
-      setActionLoadingId(eventId);
-  
-      await cancelEvent(eventId);
-  
-      await updateNotificationsByEventId(eventId, {
+      setActionLoadingId(event.id);
+
+      // If synced to Google Calendar, attempt to remove it (non-blocking)
+      if (event.googleCalendarEventId) {
+        try {
+          await deleteGoogleCalendarEvent(event.googleCalendarEventId);
+
+          try {
+            await updateEvent(event.id, {
+              calendarSyncStatus: "removed",
+              calendarSyncLabel: "Removed from Google Calendar after cancellation",
+            });
+          } catch (e) {
+            console.warn("Failed to update calendar sync metadata after Google delete", e);
+          }
+        } catch (googleErr) {
+          console.error("Failed to remove Google Calendar event", googleErr);
+          try {
+            await updateEvent(event.id, {
+              calendarSyncStatus: "failed",
+              calendarSyncLabel: "Failed to remove from Google Calendar",
+            });
+          } catch (e) {
+            console.warn("Failed to update calendar sync metadata after Google delete failure", e);
+          }
+        }
+      }
+
+      await cancelEvent(event.id);
+
+      await updateNotificationsByEventId(event.id, {
         status: "cancelled",
         statusLabel: "Meeting cancelled",
       });
@@ -87,7 +115,7 @@ export default function EventList({
       if (onDataChanged) {
         onDataChanged();
       }
-  
+
       await loadEvents();
     } catch (error) {
       console.error(error);
@@ -97,25 +125,57 @@ export default function EventList({
     }
   }
 
-  async function handleDelete(eventId) {
+  async function handleDelete(event) {
     const shouldDelete = window.confirm(
       "Are you sure you want to delete this meeting?",
     );
-  
+
     if (!shouldDelete) {
       return;
     }
-  
+
     try {
-      setActionLoadingId(eventId);
-  
-      await deleteNotificationsByEventId(eventId);
-      await deleteEvent(eventId);
+      setActionLoadingId(event.id);
+
+      // If synced to Google Calendar, attempt to remove it (non-blocking)
+      if (event.googleCalendarEventId) {
+        try {
+          await deleteGoogleCalendarEvent(event.googleCalendarEventId);
+
+          try {
+            await updateEvent(event.id, {
+              calendarSyncStatus: "removed",
+              calendarSyncLabel: "Removed from Google Calendar after deletion",
+            });
+          } catch (e) {
+            console.warn("Failed to update calendar sync metadata after Google delete", e);
+          }
+        } catch (googleErr) {
+          console.error("Failed to remove Google Calendar event", googleErr);
+          try {
+            await updateEvent(event.id, {
+              calendarSyncStatus: "failed",
+              calendarSyncLabel: "Failed to remove from Google Calendar",
+            });
+          } catch (e) {
+            console.warn("Failed to update calendar sync metadata after Google delete failure", e);
+          }
+        }
+      }
+
+      // Preserve notification history by marking them deleted
+      await updateNotificationsByEventId(event.id, {
+        status: "deleted",
+        statusLabel: "Meeting deleted",
+      });
+
+      // Soft-delete the event document (deleteEvent now performs soft-delete)
+      await deleteEvent(event.id);
 
       if (onDataChanged) {
         onDataChanged();
       }
-  
+
       await loadEvents();
     } catch (error) {
       console.error(error);
@@ -197,8 +257,8 @@ export default function EventList({
            isActionLoading={actionLoadingId === event.id}
            onEdit={setEventToEdit}
            onComplete={handleComplete}
-           onCancel={handleCancel}
-           onDelete={handleDelete}
+           onCancel={() => handleCancel(event)}
+           onDelete={() => handleDelete(event)}
          />
           ))}
         </div>

--- a/frontend/src/components/Events/EventNotifications.jsx
+++ b/frontend/src/components/Events/EventNotifications.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getNotifications } from "@/firebase/notificationsService";
+import { getUpcomingNotificationsWithinDays } from "@/firebase/notificationsService";
 
 export default function EventNotifications({
   refreshKey = 0,
@@ -12,7 +12,7 @@ export default function EventNotifications({
   async function loadNotifications() {
     try {
       setLoading(true);
-      const notificationsFromDb = await getNotifications();
+      const notificationsFromDb = await getUpcomingNotificationsWithinDays(2);
       setNotifications(notificationsFromDb);
     } catch (error) {
       console.error(error);

--- a/frontend/src/components/Events/NotificationBell.jsx
+++ b/frontend/src/components/Events/NotificationBell.jsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getNotifications } from "@/firebase/notificationsService";
+import {
+  getDueNotifications,
+  updateNotificationById,
+} from "@/firebase/notificationsService";
+import { getEventById } from "@/firebase/eventsService";
 
 export default function NotificationBell() {
   const [notifications, setNotifications] = useState([]);
@@ -9,17 +13,70 @@ export default function NotificationBell() {
 
   async function loadNotifications() {
     try {
-      const notificationsFromDb = await getNotifications();
-      setNotifications(notificationsFromDb);
+      const due = await getDueNotifications();
+
+      if (!due || due.length === 0) {
+        setNotifications([]);
+        return;
+      }
+
+      // Resolve related events in parallel (small set expected)
+      const uniqueEventIds = [...new Set(due.map((n) => n.eventId).filter(Boolean))];
+      const eventsById = {};
+
+      await Promise.all(
+        uniqueEventIds.map(async (id) => {
+          const ev = await getEventById(id);
+          eventsById[id] = ev;
+        }),
+      );
+
+      const now = new Date();
+
+      const actionable = due.filter((notification) => {
+        const ev = eventsById[notification.eventId];
+
+        if (!ev) return false;
+        if (ev.status !== "scheduled") return false;
+        if (!ev.date || !ev.time) return false;
+
+        const eventDateTime = new Date(`${ev.date}T${ev.time}`);
+        if (Number.isNaN(eventDateTime.getTime())) return false;
+
+        // only show reminders for meetings that have not yet passed
+        if (eventDateTime < now) return false;
+
+        return true;
+      });
+
+      setNotifications(actionable);
     } catch (error) {
       console.error("Failed to load reminders:", error);
+    }
+  }
+
+  async function handleDismiss(e, notificationId) {
+    e.stopPropagation();
+
+    // Optimistic UI: remove locally first
+    setNotifications((prev) => prev.filter((n) => n.id !== notificationId));
+
+    try {
+      await updateNotificationById(notificationId, {
+        status: "dismissed",
+        dismissedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      console.error("Failed to dismiss notification", err);
+      // restore from server on failure
+      await loadNotifications();
     }
   }
 
   useEffect(() => {
     const intervalId = setInterval(() => {
       loadNotifications();
-    }, 60000);
+    }, 30000);
   
     return () => clearInterval(intervalId);
   }, []);
@@ -36,7 +93,10 @@ export default function NotificationBell() {
     <div className="relative">
       <button
         type="button"
-        onClick={() => setIsOpen((current) => !current)}
+        onClick={async () => {
+          if (!isOpen) await loadNotifications();
+          setIsOpen((current) => !current);
+        }}
         className="relative rounded-2xl bg-white px-4 py-2 shadow-sm ring-1 ring-slate-200 transition hover:bg-slate-50"
       >
         🔔
@@ -57,21 +117,36 @@ export default function NotificationBell() {
           {notifications.length === 0 ? (
             <p className="text-sm text-slate-500">No upcoming reminders.</p>
           ) : (
-            <div className="space-y-3">
-              {notifications.slice(0, 5).map((notification) => (
+            <div className="space-y-3 max-h-96 overflow-y-auto">
+              {notifications.slice(0, 10).map((notification) => (
                 <div
                   key={notification.id}
                   className="rounded-2xl bg-slate-50 p-3"
                 >
-                  <p className="text-sm font-bold text-slate-900">
-                    {notification.message || "Meeting reminder"}
-                  </p>
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="text-sm font-bold text-slate-900">
+                        {notification.message || "Meeting reminder"}
+                      </p>
 
-                  <p className="mt-1 text-xs text-slate-500">
-                    {notification.scheduledFor
-                      ? new Date(notification.scheduledFor).toLocaleString()
-                      : "No time set"}
-                  </p>
+                      <p className="mt-1 text-xs text-slate-500">
+                        {notification.scheduledFor
+                          ? new Date(notification.scheduledFor).toLocaleString()
+                          : "No time set"}
+                      </p>
+                    </div>
+
+                    <div className="ml-4 shrink-0">
+                      <button
+                        type="button"
+                        onClick={(e) => handleDismiss(e, notification.id)}
+                        aria-label="Dismiss reminder"
+                        className="rounded-full bg-transparent px-2 py-1 text-sm font-bold text-slate-500 hover:text-slate-800"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  </div>
                 </div>
               ))}
             </div>

--- a/frontend/src/firebase/eventsService.js
+++ b/frontend/src/firebase/eventsService.js
@@ -1,7 +1,6 @@
 import {
   addDoc,
   collection,
-  deleteDoc,
   doc,
   getDocs,
   orderBy,
@@ -71,8 +70,13 @@ import {
   
   export async function deleteEvent(eventId) {
     const eventRef = doc(db, EVENTS_COLLECTION, eventId);
-  
-    await deleteDoc(eventRef);
+
+    // Soft-delete: preserve history in Firestore
+    await updateDoc(eventRef, {
+      status: "deleted",
+      deletedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
   }
 
   export async function updateEvent(eventId, updatedData) {

--- a/frontend/src/firebase/eventsService.js
+++ b/frontend/src/firebase/eventsService.js
@@ -2,6 +2,7 @@ import {
   addDoc,
   collection,
   doc,
+  getDoc,
   getDocs,
   orderBy,
   query,
@@ -52,6 +53,36 @@ import {
       });
   }
 
+  // Return scheduled events within the next `days` days (client-side filter)
+  export async function getEventsWithinDays(days) {
+    const eventsQuery = query(
+      collection(db, EVENTS_COLLECTION),
+      orderBy("date", "asc")
+    );
+
+    const snapshot = await getDocs(eventsQuery);
+
+    const now = new Date();
+    const until = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+
+    return snapshot.docs
+      .map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      }))
+      .filter((event) => {
+        if (!event.date || !event.time) return false;
+
+        const eventDateTime = new Date(`${event.date}T${event.time}`);
+
+        return (
+          eventDateTime >= now &&
+          eventDateTime <= until &&
+          event.status === "scheduled"
+        );
+      });
+  }
+
   export async function completeEvent(eventId) {
     const eventRef = doc(db, EVENTS_COLLECTION, eventId);
   
@@ -86,4 +117,19 @@ import {
       ...updatedData,
       updatedAt: serverTimestamp(),
     });
+  }
+
+  // Read a single event document by id. Returns null if not found.
+  export async function getEventById(eventId) {
+    try {
+      const eventRef = doc(db, EVENTS_COLLECTION, eventId);
+      const snap = await getDoc(eventRef);
+
+      if (!snap.exists()) return null;
+
+      return { id: snap.id, ...snap.data() };
+    } catch (err) {
+      console.error("getEventById error", err);
+      return null;
+    }
   }

--- a/frontend/src/firebase/notificationsService.js
+++ b/frontend/src/firebase/notificationsService.js
@@ -52,6 +52,62 @@ export async function getNotifications() {
     });
 }
 
+// Return due notifications (pending and scheduledFor <= now)
+export async function getDueNotifications() {
+  const notificationsQuery = query(
+    collection(db, NOTIFICATIONS_COLLECTION),
+    orderBy("scheduledFor", "asc"),
+  );
+
+  const snapshot = await getDocs(notificationsQuery);
+  const now = new Date();
+
+  return snapshot.docs
+    .map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }))
+    .filter((notification) => {
+      if (!notification.scheduledFor) return false;
+
+      const reminderDateTime = new Date(notification.scheduledFor);
+
+      return (
+        reminderDateTime <= now &&
+        notification.status === "pending"
+      );
+    });
+}
+
+// Return upcoming notifications within N days (inclusive)
+export async function getUpcomingNotificationsWithinDays(days) {
+  const notificationsQuery = query(
+    collection(db, NOTIFICATIONS_COLLECTION),
+    orderBy("scheduledFor", "asc"),
+  );
+
+  const snapshot = await getDocs(notificationsQuery);
+  const now = new Date();
+  const until = new Date(now.getTime() + days * 24 * 60 * 60 * 1000);
+
+  return snapshot.docs
+    .map((doc) => ({
+      id: doc.id,
+      ...doc.data(),
+    }))
+    .filter((notification) => {
+      if (!notification.scheduledFor) return false;
+
+      const reminderDateTime = new Date(notification.scheduledFor);
+
+      return (
+        reminderDateTime >= now &&
+        reminderDateTime <= until &&
+        notification.status === "pending"
+      );
+    });
+}
+
 export async function updateNotificationsByEventId(eventId, updateData) {
   const notificationsQuery = query(
     collection(db, NOTIFICATIONS_COLLECTION),
@@ -80,4 +136,11 @@ export async function deleteNotificationsByEventId(eventId) {
       deleteDoc(doc(db, NOTIFICATIONS_COLLECTION, notificationDoc.id)),
     ),
   );
+}
+
+// Update a single notification by id
+export async function updateNotificationById(notificationId, updateData) {
+  const notificationRef = doc(db, NOTIFICATIONS_COLLECTION, notificationId);
+
+  await updateDoc(notificationRef, updateData);
 }


### PR DESCRIPTION
## Summary

This PR improves the meeting lifecycle, Google Calendar cleanup behavior, and the visibility of events and reminders in the system.

It preserves meeting history in Firestore, replaces hard deletion with soft deletion, cleans up synced Google Calendar events when meetings are cancelled or deleted, and improves the Events page and notification bell so they show only relevant and actionable information.

## Main Changes

### Meeting Lifecycle

Updated the meeting lifecycle so that cancelled, completed, and deleted meetings remain preserved in Firestore for future history views.

* Cancelled meetings remain in Firestore with `status: "cancelled"`.
* Deleted meetings remain in Firestore with `status: "deleted"` and `deletedAt`.
* Completed meetings remain in Firestore with `status: "completed"`.
* `deleteEvent` was changed from a hard delete to a soft delete.
* Completed meetings are preserved as historical records.

### Google Calendar Cleanup

Improved Google Calendar lifecycle behavior for synced meetings.

* Cancelled synced meetings are removed from Google Calendar.
* Deleted synced meetings are removed from Google Calendar.
* Completed synced meetings are not removed from Google Calendar, because they represent meetings that actually took place.
* Google Calendar cleanup failures do not block the system action.
* Calendar sync metadata is updated when Google Calendar cleanup succeeds or fails.

### Notification History

Notification history is preserved instead of being removed permanently.

* Deleted meeting reminders are marked with `status: "deleted"` instead of being physically deleted.
* Completed meeting reminders are marked with `status: "completed"`.
* Cancelled meeting reminders are marked with `status: "cancelled"`.

### Events Page Visibility

Improved the Events page so it does not become overloaded.

* The main Events list now shows only scheduled meetings within the next 2 days.
* Added a dedicated helper: `getEventsWithinDays(days)`.
* Kept the original `getEvents()` function unchanged for future broader views, such as an internal calendar or history view.

### Upcoming Reminders Visibility

Improved the upcoming reminders section on the Events page.

* Upcoming reminders now show only pending reminders within the next 2 days.
* Added a dedicated helper: `getUpcomingNotificationsWithinDays(days)`.
* Kept the original `getNotifications()` function unchanged for backward compatibility.

### Notification Bell

Improved the notification bell so it behaves like an actionable notification inbox.

The bell now shows reminders only when:

* The reminder status is `pending`.
* The reminder time has arrived.
* The related meeting still exists.
* The related meeting is still `scheduled`.
* The related meeting has not already passed.

Additional bell improvements:

* Added dismiss support for individual reminders.
* Dismissed reminders are updated in Firestore with:

  * `status: "dismissed"`
  * `dismissedAt`
* Added `updateNotificationById(notificationId, updateData)` for updating a single reminder.
* Added `getEventById(eventId)` for validating whether a reminder is still relevant to an active meeting.
* The bell refreshes automatically every 30 seconds.
* Opening the bell triggers an immediate refresh.
* Dismissing a reminder removes it from the UI immediately using optimistic update.
* If dismiss fails, the bell reloads from the server.
* The notification dropdown is now scrollable so many reminders do not take over the whole screen.

## Files Changed

### `frontend/src/firebase/eventsService.js`

* Changed `deleteEvent` from hard delete to soft delete.
* Added `getEventsWithinDays(days)`.
* Added `getEventById(eventId)`.

### `frontend/src/firebase/notificationsService.js`

* Added `getDueNotifications()`.
* Added `getUpcomingNotificationsWithinDays(days)`.
* Added `updateNotificationById(notificationId, updateData)`.

### `frontend/src/components/Events/EventList.jsx`

* Uses `getEventsWithinDays(2)` so the main Events list shows only meetings within the next 2 days.
* Added Google Calendar cleanup for cancelled/deleted synced meetings.
* Preserved notification history for deleted meetings.
* Kept completed meeting behavior unchanged.

### `frontend/src/components/Events/EventNotifications.jsx`

* Uses `getUpcomingNotificationsWithinDays(2)` so upcoming reminders are limited to the next 2 days.

### `frontend/src/components/Events/NotificationBell.jsx`

* Shows only due, actionable reminders.
* Filters out reminders for passed, missing, or non-scheduled meetings.
* Adds dismiss action for reminders.
* Refreshes automatically every 30 seconds.
* Refreshes immediately when opened.
* Uses optimistic UI update when dismissing reminders.
* Adds scrollable dropdown behavior.

## Behavior

* Cancelled meetings remain in Firestore as `cancelled`.
* Deleted meetings remain in Firestore as `deleted`.
* Completed meetings remain in Firestore as `completed`.
* Cancelled/deleted synced meetings are removed from Google Calendar.
* Completed synced meetings remain in Google Calendar.
* Google Calendar cleanup failures do not block the local system action.
* The main Events list shows only scheduled meetings within the next 2 days.
* Upcoming reminders on the Events page show only reminders within the next 2 days.
* The notification bell shows only due reminders that are still relevant.
* Old reminders for meetings that already passed no longer remain visible in the bell.
* Dismissed reminders disappear immediately from the bell.

## Testing

Tested locally by:

* Cancelling a synced meeting and confirming:

  * It remained in Firestore with `status: "cancelled"`.
  * It was removed from Google Calendar.
  * Its reminders were marked as cancelled.

* Deleting a synced meeting and confirming:

  * It remained in Firestore with `status: "deleted"`.
  * It received `deletedAt`.
  * It was removed from Google Calendar.
  * Its reminders were marked as deleted.

* Completing a synced meeting and confirming:

  * It remained in Firestore with `status: "completed"`.
  * It stayed in Google Calendar.
  * Its reminders were marked as completed.

* Confirming the main Events list shows only scheduled meetings within the next 2 days.

* Confirming upcoming reminders on the Events page show only reminders within the next 2 days.

* Confirming future reminders do not appear in the notification bell before their scheduled time.

* Confirming due reminders appear in the notification bell.

* Confirming reminders for passed, cancelled, completed, deleted, or missing meetings do not appear in the bell.

* Confirming clicking dismiss removes the reminder immediately from the bell.

* Confirming dismissed reminders are updated in Firestore with `status: "dismissed"` and `dismissedAt`.

* Confirming the bell refreshes when opened and automatically every 30 seconds.

* Confirming the notification dropdown is scrollable when many reminders exist.

## Notes

This PR intentionally uses client-side filtering for the time-based visibility logic to avoid adding Firestore composite indexes at this stage.

The original `getEvents()` and `getNotifications()` functions were kept unchanged for backward compatibility and future features, such as an internal calendar view or full meeting history view.
