### PR TITLE
Secure Client Onboarding & Main Merge

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,176 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+
+    function accountPath(uid) {
+      return /databases/$(database)/documents/accounts/$(uid);
+    }
+
+    function invitePath(inviteToken) {
+      return /databases/$(database)/documents/client_invites/$(inviteToken);
+    }
+
+    function hasAccount() {
+      return signedIn() && exists(accountPath(request.auth.uid));
+    }
+
+    function accountData() {
+      return get(accountPath(request.auth.uid)).data;
+    }
+
+    function accountRole() {
+      return hasAccount() ? accountData().role : null;
+    }
+
+    function isAdmin() {
+      return accountRole() == "Admin";
+    }
+
+    function isStaff() {
+      return accountRole() in ["Admin", "Program Manager"];
+    }
+
+    function isClientRole(role) {
+      return role in ["client", "Client"];
+    }
+
+    function isOwnAccount(accountId) {
+      return signedIn() && accountId == request.auth.uid;
+    }
+
+    function claimedInviteMatches(inviteToken, clientId) {
+      return inviteToken is string
+        && existsAfter(invitePath(inviteToken))
+        && getAfter(invitePath(inviteToken)).data.status == "claimed"
+        && getAfter(invitePath(inviteToken)).data.claimedByUid == request.auth.uid
+        && getAfter(invitePath(inviteToken)).data.clientId == clientId;
+    }
+
+    function isDefaultSelfAccountCreate(accountId) {
+      return isOwnAccount(accountId)
+        && request.resource.data.account_id == request.auth.uid
+        && request.resource.data.role == "User"
+        && !("clientId" in request.resource.data)
+        && !("clientInviteToken" in request.resource.data);
+    }
+
+    function isClientSelfAccountWrite(accountId) {
+      return isOwnAccount(accountId)
+        && request.resource.data.account_id == request.auth.uid
+        && isClientRole(request.resource.data.role)
+        && request.resource.data.clientId is string
+        && claimedInviteMatches(
+          request.resource.data.clientInviteToken,
+          request.resource.data.clientId
+        );
+    }
+
+    function isSafeSelfAccountUpdate(accountId) {
+      return isOwnAccount(accountId)
+        && resource.data.account_id == request.auth.uid
+        && request.resource.data.account_id == resource.data.account_id
+        && request.resource.data.role == resource.data.role
+        && request.resource.data.clientId == resource.data.clientId;
+    }
+
+    function isInviteClaim(inviteToken) {
+      return signedIn()
+        && (!("status" in resource.data) || resource.data.status == "pending")
+        && request.resource.data.clientId == resource.data.clientId
+        && request.resource.data.status == "claimed"
+        && request.resource.data.claimedByUid == request.auth.uid
+        && request.resource.data.diff(resource.data).affectedKeys()
+          .hasOnly(["status", "claimedByUid", "claimedAt"]);
+    }
+
+    function isMappedClient(clientId) {
+      return hasAccount()
+        && isClientRole(accountData().role)
+        && accountData().clientId == clientId;
+    }
+
+    function isClientProfileUpdate(clientId) {
+      return isMappedClient(clientId)
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+          "first_name",
+          "last_name",
+          "email",
+          "phone",
+          "passport_id",
+          "gender",
+          "address",
+          "dob",
+          "referrer",
+          "education_status",
+          "diagnosis",
+          "personal_notes",
+          "passport_number",
+          "passport_country",
+          "citizenship",
+          "date_of_entry",
+          "purpose_of_visit",
+          "home_address",
+          "cohabitants",
+          "dependents",
+          "medical_profile",
+          "contacts",
+          "logistics",
+          "questionnaire",
+          "legal_consents",
+          "financial_aid_applications",
+          "client_documents"
+        ]);
+    }
+
+    function isClientUidClaim(clientId) {
+      return signedIn()
+        && (!("uid" in resource.data) || resource.data.uid == null || resource.data.uid == request.auth.uid)
+        && request.resource.data.uid == request.auth.uid
+        && request.resource.data.diff(resource.data).affectedKeys()
+          .hasOnly(["uid", "updated_at"])
+        && existsAfter(accountPath(request.auth.uid))
+        && isClientRole(getAfter(accountPath(request.auth.uid)).data.role)
+        && getAfter(accountPath(request.auth.uid)).data.clientId == clientId;
+    }
+
+    match /accounts/{accountId} {
+      allow get: if isOwnAccount(accountId) || isAdmin();
+      allow list: if isAdmin();
+      allow create: if isDefaultSelfAccountCreate(accountId)
+        || isClientSelfAccountWrite(accountId)
+        || isAdmin();
+      allow update: if isAdmin()
+        || isSafeSelfAccountUpdate(accountId)
+        || isClientSelfAccountWrite(accountId);
+      allow delete: if isAdmin();
+    }
+
+    match /client_invites/{inviteToken} {
+      // The invite token is an unguessable document ID. Users must already know
+      // the token from an invite link before they can read or claim it.
+      allow get: if signedIn();
+      allow list: if isStaff();
+      allow create, delete: if isStaff();
+      allow update: if isStaff() || isInviteClaim(inviteToken);
+    }
+
+    match /clients/{clientId} {
+      allow get: if isStaff() || isMappedClient(clientId);
+      allow list: if isStaff();
+      allow create, delete: if isStaff();
+      allow update: if isStaff()
+        || isClientProfileUpdate(clientId)
+        || isClientUidClaim(clientId);
+    }
+
+    // Preserve manager access to the remaining operational collections while
+    // keeping client accounts constrained to the explicit rules above.
+    match /{document=**} {
+      allow read, write: if isStaff();
+    }
+  }
+}

--- a/frontend/src/app/(client)/onboarding/page.tsx
+++ b/frontend/src/app/(client)/onboarding/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { onAuthStateChanged, signOut } from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import ClientDataForm from "@/components/clients/forms/ClientDataForm";
+import type { ClientDoc } from "@/components/clients/list/ClientList";
+import { auth, db } from "@/firebase/firebase";
+import {
+  CLIENT_EMAIL_VERIFICATION_PATH,
+  getAccountForUser,
+  isClientRole,
+} from "@/firebase/authRoleService";
+import freeSpiritLogo from "../../../../docs/design-reference/image.png";
+
+type OnboardingState =
+  | { status: "loading"; client: null; message: string }
+  | { status: "ready"; client: ClientDoc; message: string }
+  | { status: "error"; client: null; message: string };
+
+type AuthAccount = {
+  id: string;
+  role?: unknown;
+  clientId?: unknown;
+};
+
+export default function ClientOnboardingPage() {
+  const router = useRouter();
+  const [isMounted, setIsMounted] = useState(false);
+  const [state, setState] = useState<OnboardingState>({
+    status: "loading",
+    client: null,
+    message: "Loading your onboarding profile...",
+  });
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [logoutError, setLogoutError] = useState("");
+
+  useEffect(() => {
+    // Defer the mount flag so the first client render exactly matches SSR.
+    const timeoutId = window.setTimeout(() => {
+      setIsMounted(true);
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+
+    if (!auth || !db) {
+      const timeoutId = window.setTimeout(() => {
+        setState({
+          status: "error",
+          client: null,
+          message: "Firebase is not initialized.",
+        });
+      }, 0);
+
+      return () => window.clearTimeout(timeoutId);
+    }
+
+    let shouldIgnore = false;
+    const activeAuth = auth;
+    const activeDb = db;
+
+    const unsubscribe = onAuthStateChanged(activeAuth, async (user) => {
+      if (!user) {
+        router.replace("/login");
+        return;
+      }
+
+      try {
+        await user.reload();
+        const refreshedUser = activeAuth.currentUser || user;
+
+        if (!refreshedUser.emailVerified) {
+          router.replace(CLIENT_EMAIL_VERIFICATION_PATH);
+          return;
+        }
+
+        const account = (await getAccountForUser(user)) as AuthAccount | null;
+
+        if (!account || !isClientRole(account.role)) {
+          router.replace("/home");
+          return;
+        }
+
+        if (!account.clientId || typeof account.clientId !== "string") {
+          throw new Error("Your account is not linked to a client profile yet.");
+        }
+
+        const clientSnapshot = await getDoc(
+          doc(activeDb, "clients", account.clientId),
+        );
+
+        if (!clientSnapshot.exists()) {
+          throw new Error("Your linked client profile could not be found.");
+        }
+
+        if (shouldIgnore) {
+          return;
+        }
+
+        // The clientId comes from accounts/{uid}; Firestore rules then verify
+        // the same mapping before allowing this clients/{clientId} read.
+        setState({
+          status: "ready",
+          client: {
+            id: clientSnapshot.id,
+            ...clientSnapshot.data(),
+          } as ClientDoc,
+          message: "",
+        });
+      } catch (error) {
+        if (shouldIgnore) {
+          return;
+        }
+
+        setState({
+          status: "error",
+          client: null,
+          message:
+            error instanceof Error
+              ? error.message
+              : "Unable to load your onboarding profile.",
+        });
+      }
+    });
+
+    return () => {
+      shouldIgnore = true;
+      unsubscribe();
+    };
+  }, [isMounted, router]);
+
+  async function handleLogout() {
+    if (!auth) {
+      setLogoutError("Firebase is not initialized.");
+      return;
+    }
+
+    setLogoutError("");
+    setIsLoggingOut(true);
+
+    try {
+      // Keep onboarding standalone while still using Firebase Auth as the
+      // session authority; replace history so Back cannot reopen the form.
+      await signOut(auth);
+      router.replace("/login");
+    } catch (error) {
+      setLogoutError(
+        error instanceof Error ? error.message : "Failed to log out.",
+      );
+    } finally {
+      setIsLoggingOut(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#F7FAF5_0%,#EEF5F7_100%)] px-4 py-6 text-[#15383E] sm:px-6 sm:py-8">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header className="grid gap-4 sm:grid-cols-[1fr_auto_1fr] sm:items-start">
+          <div className="hidden sm:block" aria-hidden="true" />
+
+          <div className="flex flex-col items-center gap-3 text-center">
+            <span className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white p-2 ring-1 ring-[#D7E3D5]">
+              <Image
+                src={freeSpiritLogo}
+                alt="Free Spirit"
+                className="h-auto w-full object-contain"
+                priority
+                sizes="64px"
+              />
+            </span>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.18em] text-[#6A8589]">
+                Free Spirit
+              </p>
+              <h1 className="mt-1 text-2xl font-bold tracking-[-0.03em] text-[#15383E] sm:text-3xl">
+                Client Onboarding
+              </h1>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center gap-2 sm:items-end">
+            <button
+              type="button"
+              onClick={handleLogout}
+              disabled={isLoggingOut}
+              className="rounded-full border border-[#B9CFCA] bg-white/65 px-4 py-2 text-sm font-bold text-[#31585F] transition hover:bg-white hover:text-[#173A40] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6BB2A0] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isLoggingOut ? "Logging out..." : "Log Out"}
+            </button>
+            {logoutError && (
+              <p className="max-w-56 text-center text-xs font-semibold text-red-700 sm:text-right">
+                {logoutError}
+              </p>
+            )}
+          </div>
+        </header>
+
+        {state.status === "ready" ? (
+          <ClientDataForm client={state.client} isEditable={true} />
+        ) : (
+          <section className="rounded-[1.75rem] border border-white/80 bg-[#FFFDF8] p-6 text-center shadow-[0_14px_34px_rgba(44,105,117,0.08)]">
+            <p className="text-sm font-bold text-[#31585F]">{state.message}</p>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/(protected)/admin/accounts/page.jsx
+++ b/frontend/src/app/(protected)/admin/accounts/page.jsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { collection, getDocs, doc, updateDoc , deleteDoc } from "firebase/firestore";
+import { collection, getDocs, doc, updateDoc , deleteDoc, serverTimestamp } from "firebase/firestore";
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { db } from "@/firebase/firebase";
 
-const roleOptions = ["User", "Program Manager", "Admin"];
+const roleOptions = ["User", "Program Manager", "Admin", "client"];
 
 const formatCreatedAt = (createdAt) => {
   if (!createdAt?.toDate) {
@@ -13,6 +13,14 @@ const formatCreatedAt = (createdAt) => {
   }
 
   return createdAt.toDate().toLocaleString();
+};
+
+const formatAccountTimestamp = (timestamp) => {
+  if (!timestamp?.toDate) {
+    return "Unknown";
+  }
+
+  return timestamp.toDate().toLocaleString();
 };
 
 export default function AdminUsersPage() {
@@ -75,6 +83,7 @@ export default function AdminUsersPage() {
     try {
       await updateDoc(doc(db, "accounts", userId), {
         role: nextRole,
+        updated_at: serverTimestamp(),
       });
 
       setUsers((currentUsers) =>
@@ -155,6 +164,7 @@ export default function AdminUsersPage() {
                 <th className="px-4 py-3">Email</th>
                 <th className="px-4 py-3">Current Role</th>
                 <th className="px-4 py-3">Created</th>
+                <th className="px-4 py-3">Last Login</th>
                 <th className="px-4 py-3">Update Role</th>
                 <th className="px-4 py-3 text-right">Actions</th>
               </tr>
@@ -162,13 +172,13 @@ export default function AdminUsersPage() {
             <tbody className="divide-y divide-slate-200">
               {isLoading ? (
                 <tr>
-                  <td className="px-4 py-6 text-center text-slate-500" colSpan="4">
+                  <td className="px-4 py-6 text-center text-slate-500" colSpan="6">
                     Loading users...
                   </td>
                 </tr>
               ) : users.length === 0 ? (
                 <tr>
-                  <td className="px-4 py-6 text-center text-slate-500" colSpan="4">
+                  <td className="px-4 py-6 text-center text-slate-500" colSpan="6">
                     No users found.
                   </td>
                 </tr>
@@ -180,6 +190,7 @@ export default function AdminUsersPage() {
                     </td>
                     <td className="px-4 py-3">{user.role || "User"}</td>
                     <td className="px-4 py-3">{formatCreatedAt(user.created_at)}</td>
+                    <td className="px-4 py-3">{formatAccountTimestamp(user.last_login)}</td>
                     <td className="px-4 py-3">
                       <select
                         className="w-full max-w-[220px] rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 outline-none transition focus:border-blue-600 focus:shadow-[0_0_0_3px_rgba(37,99,235,0.14)] disabled:cursor-not-allowed disabled:opacity-70"

--- a/frontend/src/app/(protected)/admin/permissions/page.jsx
+++ b/frontend/src/app/(protected)/admin/permissions/page.jsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useNavigation } from "@/components/NavigationProvider/NavigationContext";
 import { db } from "@/firebase/firebase";
 
-const roleOptions = ["User", "Program Manager", "Admin"];
+const roleOptions = ["User", "Program Manager", "Admin", "client"];
 
 export default function AdminPermissionsPage() {
   const { links, isLoadingLinks, linksError, setLinks } = useNavigation();

--- a/frontend/src/app/(protected)/programs/page.jsx
+++ b/frontend/src/app/(protected)/programs/page.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import { collection, getDocs, doc, updateDoc, deleteDoc } from "firebase/firestore";
-import { Plus, CalendarDays, MapPin, UsersRound, CheckCircle2, X } from "lucide-react";
+import { Plus, CalendarDays, UsersRound, CheckCircle2, X } from "lucide-react";
 import { db, isFirebaseInitialized } from "@/firebase/firebase";
 import ManagePrograms from "../manage-programs/page";
 

--- a/frontend/src/app/(protected)/statistic/page.jsx
+++ b/frontend/src/app/(protected)/statistic/page.jsx
@@ -4,10 +4,8 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { 
   Users, 
   CalendarCheck, 
-  TrendingUp, 
   AlertCircle,
   Activity,
-  FileWarning,
   UserX,
   ClipboardCheck,
   Megaphone,
@@ -30,8 +28,6 @@ import {
   ResponsiveContainer 
 } from 'recharts';
 
-
-import Link from 'next/link';
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "@/firebase/firebase";
 
@@ -202,7 +198,7 @@ export default function StatisticsPage() {
     });
 
     const demographicsData = Object.entries(ageGroups)
-      .filter(([_, value]) => value > 0)
+      .filter(([, value]) => value > 0)
       .map(([name, value]) => ({ name, value }));
 
     const growthData = Object.entries(monthCounts).map(([month, signups]) => ({
@@ -221,7 +217,7 @@ export default function StatisticsPage() {
 
     // Retention data for donut chart
     const retentionData = Object.entries(retentionCounts)
-      .filter(([_, value]) => value > 0)
+      .filter(([, value]) => value > 0)
       .map(([name, value]) => ({ name, value }));
 
     // Top 5 Locations
@@ -273,7 +269,6 @@ export default function StatisticsPage() {
     demographicsData = [],
     growthData = [],
     programOccupancyData = [],
-    actionItems = [],
     complianceData = [],
     referralData = [],
     retentionData = [],

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Toaster } from "sonner";
-import Navbar from "@/components/Navbar/Navbar";
+import AppNavbar from "@/components/Navbar/AppNavbar";
 import "./globals.css";
 import { NavigationProvider } from "@/components/NavigationProvider/NavigationContext";
 
@@ -19,8 +19,8 @@ export default function RootLayout({
       <body className="min-h-full flex flex-col">
         {/* Wrap the global components inside the dynamic navigation context */}
         <NavigationProvider>
-          {/* Navbar is mounted globally so auth links and logout are available everywhere. */}
-          <Navbar />
+          {/* AppNavbar hides itself only on standalone client-facing flows. */}
+          <AppNavbar />
           <Toaster />
           {children}
         </NavigationProvider>

--- a/frontend/src/application/ClientManagementService.ts
+++ b/frontend/src/application/ClientManagementService.ts
@@ -4,7 +4,7 @@ import { type ClientDoc } from "@/components/clients/list/ClientList";
 import type { ClientFormInput } from "@/schema/clientSchema";
 
 // Import purely from our Tier 4 Data Layer!
-import { subscribeToClients, restoreClientInDb, createClientDoc, updateClientDoc } from "@/firebase/clientDbService";
+import { subscribeToClients, restoreClientInDb, createClientDoc, updateClientDoc, createClientInviteDoc } from "@/firebase/clientDbService";
 import { createSystemEvent } from "@/firebase/clientEventsService";
 
 /**
@@ -176,4 +176,36 @@ export async function registerClient(
   clientName: string
 ): Promise<void> {
   return updateClientStatus(clientId, clientName, "registered", "System");
+}
+
+function createSecureInviteToken(): string {
+  if (typeof crypto === "undefined" || !crypto.getRandomValues) {
+    throw new Error("Secure token generation is not available in this browser.");
+  }
+
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Generates a one-time client invite URL and persists the token document.
+ *
+ * Tier 2 responsibility: owns the workflow contract and user feedback.
+ * Tier 4 responsibility: performs the Firestore write in createClientInviteDoc.
+ */
+export async function createClientInviteLink(
+  clientId: string,
+  origin: string
+): Promise<string> {
+  if (!clientId) {
+    throw new Error("A client ID is required to generate an invite link.");
+  }
+
+  const inviteToken = createSecureInviteToken();
+  await createClientInviteDoc(clientId, inviteToken);
+  toast.success("Invite link generated.");
+
+  return `${origin}/signup?inviteToken=${inviteToken}`;
 }

--- a/frontend/src/application/useClientPrograms.ts
+++ b/frontend/src/application/useClientPrograms.ts
@@ -45,24 +45,24 @@ export function useClientPrograms(
   programIds: string[] = []
 ): UseClientProgramsReturn {
   const [allPrograms, setAllPrograms] = useState<ProgramSummary[]>([]);
-  const [localProgramIds, setLocalProgramIds] = useState<string[]>(programIds);
+  const [localProgramState, setLocalProgramState] = useState<{
+    clientId: string;
+    programIds: string[];
+  }>({ clientId, programIds });
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // ── Keep local IDs in sync if the parent re-renders with a new client ──────
-  useEffect(() => {
-    setLocalProgramIds(programIds);
-  }, [clientId]); // eslint-disable-line react-hooks/exhaustive-deps
-  // Note: We intentionally depend only on clientId (not programIds) here so
-  // that optimistic updates aren't clobbered by React re-renders triggered by
-  // the parent passing down the same prop during a Firestore real-time update.
+  // Derive the active IDs during render instead of synchronizing props into
+  // state from an effect. This preserves optimistic edits for the current
+  // client while resetting naturally when a different client is opened.
+  const localProgramIds =
+    localProgramState.clientId === clientId
+      ? localProgramState.programIds
+      : programIds;
 
   // ── Load all programs once on mount ──────────────────────────────────────────
   useEffect(() => {
     let isCancelled = false;
-
-    setIsLoading(true);
-    setError(null);
 
     fetchAllPrograms()
       .then((programs) => {
@@ -97,44 +97,70 @@ export function useClientPrograms(
   const assign = useCallback(
     async (programId: string) => {
       // Optimistic update — add to local IDs immediately
-      setLocalProgramIds((prev) =>
-        prev.includes(programId) ? prev : [...prev, programId]
-      );
+      setLocalProgramState((prev) => {
+        const currentIds = prev.clientId === clientId ? prev.programIds : programIds;
+        return {
+          clientId,
+          programIds: currentIds.includes(programId)
+            ? currentIds
+            : [...currentIds, programId],
+        };
+      });
 
       try {
         await assignClientToProgram(clientId, programId);
         toast.success("Client enrolled in program.");
       } catch (err) {
         // Revert optimistic update on failure
-        setLocalProgramIds((prev) => prev.filter((id) => id !== programId));
+        setLocalProgramState((prev) => {
+          const currentIds = prev.clientId === clientId ? prev.programIds : programIds;
+          return {
+            clientId,
+            programIds: currentIds.filter((id) => id !== programId),
+          };
+        });
         const message =
           err instanceof Error ? err.message : "Failed to assign program.";
         setError(message);
         toast.error("Failed to enroll client in program.");
       }
     },
-    [clientId]
+    [clientId, programIds]
   );
 
   // ── Action: Remove ────────────────────────────────────────────────────────────
   const remove = useCallback(
     async (programId: string) => {
       // Optimistic update — remove from local IDs immediately
-      setLocalProgramIds((prev) => prev.filter((id) => id !== programId));
+      setLocalProgramState((prev) => {
+        const currentIds = prev.clientId === clientId ? prev.programIds : programIds;
+        return {
+          clientId,
+          programIds: currentIds.filter((id) => id !== programId),
+        };
+      });
 
       try {
         await removeClientFromProgram(clientId, programId);
         toast.success("Client removed from program.");
       } catch (err) {
         // Revert optimistic update on failure
-        setLocalProgramIds((prev) => [...prev, programId]);
+        setLocalProgramState((prev) => {
+          const currentIds = prev.clientId === clientId ? prev.programIds : programIds;
+          return {
+            clientId,
+            programIds: currentIds.includes(programId)
+              ? currentIds
+              : [...currentIds, programId],
+          };
+        });
         const message =
           err instanceof Error ? err.message : "Failed to remove program.";
         setError(message);
         toast.error("Failed to remove client from program.");
       }
     },
-    [clientId]
+    [clientId, programIds]
   );
 
   return {

--- a/frontend/src/components/Login/Login.jsx
+++ b/frontend/src/components/Login/Login.jsx
@@ -13,6 +13,12 @@ import {
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { auth } from "@/firebase/firebase";
+import {
+  claimClientInviteForUser,
+  CLIENT_EMAIL_VERIFICATION_PATH,
+  getInviteTokenFromCurrentUrl,
+  getPostLoginRedirect,
+} from "@/firebase/authRoleService";
 import styles from "./Login.module.css";
 
 // Inline Google mark used by the OAuth button without adding another asset file.
@@ -42,6 +48,30 @@ function GoogleLogo() {
       />
     </svg>
   );
+}
+
+async function getSecurePostAuthRedirect(user) {
+  const inviteToken = getInviteTokenFromCurrentUrl();
+
+  if (inviteToken) {
+    try {
+      // Existing users may open a client invite from the login page; claim it
+      // before route selection so Firestore rules can authorize /onboarding.
+      await claimClientInviteForUser(user, inviteToken);
+    } catch (error) {
+      const fallbackRedirect = await getPostLoginRedirect(user);
+
+      if (fallbackRedirect !== "/home") {
+        return fallbackRedirect;
+      }
+
+      throw error;
+    }
+
+    return user.emailVerified ? "/onboarding" : CLIENT_EMAIL_VERIFICATION_PATH;
+  }
+
+  return getPostLoginRedirect(user);
 }
 
 export default function Login() {
@@ -74,9 +104,21 @@ export default function Login() {
 
   useEffect(() => {
     // If Firebase restores an existing session, skip login unless showing a denial.
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user && !wasAccessDenied && !wasEmailNotVerified) {
-        router.replace("/home");
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user && !wasAccessDenied) {
+        await user.reload();
+        const refreshedUser = auth.currentUser || user;
+        const redirectPath = await getSecurePostAuthRedirect(refreshedUser);
+
+        if (redirectPath === CLIENT_EMAIL_VERIFICATION_PATH) {
+          setAuthError(
+            "Please verify your email address before continuing to onboarding.",
+          );
+          setIsCheckingAuth(false);
+          return;
+        }
+
+        router.replace(redirectPath);
         return;
       }
 
@@ -84,7 +126,7 @@ export default function Login() {
     });
 
     return unsubscribe;
-  }, [router, wasAccessDenied, wasEmailNotVerified]);
+  }, [router, wasAccessDenied]);
 
   useEffect(() => {
     if (!showAccessDenied) {
@@ -165,12 +207,12 @@ export default function Login() {
         rememberMe ? browserLocalPersistence : browserSessionPersistence,
       );
 
-      await signInWithEmailAndPassword(
+      const userCredential = await signInWithEmailAndPassword(
         auth,
         credentials.email,
         credentials.password,
       );
-      router.push("/home");
+      router.push(await getSecurePostAuthRedirect(userCredential.user));
     } catch (error) {
       setAuthError(getFirebaseErrorMessage(error));
     } finally {
@@ -213,7 +255,7 @@ export default function Login() {
         localStorage.setItem("googleCalendarAccessToken", accessToken);
       }
 
-      router.push("/home");
+      router.push(await getSecurePostAuthRedirect(result.user));
     } catch (error) {
       setAuthError(getFirebaseErrorMessage(error));
     } finally {
@@ -239,6 +281,15 @@ export default function Login() {
           role="alert"
         >
           You do not have permission to access that page.
+        </div>
+      )}
+
+      {wasEmailNotVerified && (
+        <div
+          className="fixed left-1/2 top-24 z-[60] w-[min(92vw,460px)] -translate-x-1/2 rounded-2xl border border-[#E5C97D] bg-[#FFF8E8] px-5 py-4 text-center text-sm font-bold text-[#8A6822] shadow-lg"
+          role="alert"
+        >
+          Please verify your email address before continuing to onboarding.
         </div>
       )}
 

--- a/frontend/src/components/Navbar/AppNavbar.tsx
+++ b/frontend/src/components/Navbar/AppNavbar.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Navbar from "./Navbar";
+
+const NAVBARLESS_PATHS = new Set(["/login", "/onboarding", "/signup"]);
+
+/**
+ * Keeps the existing global navigation behavior for current routes while
+ * allowing intentionally standalone client-facing flows to opt out.
+ */
+export default function AppNavbar() {
+  const pathname = usePathname();
+
+  if (NAVBARLESS_PATHS.has(pathname)) {
+    return null;
+  }
+
+  return <Navbar />;
+}

--- a/frontend/src/components/Navbar/Navbar.jsx
+++ b/frontend/src/components/Navbar/Navbar.jsx
@@ -17,6 +17,7 @@ import { useEffect, useState } from "react";
 
 import { getVisibleLinks, navigationLinks } from "@/config/accessControl";
 import { useNavigation } from "@/components/NavigationProvider/NavigationContext"; // Make sure this path matches where you saved it
+import { isStaffRole } from "@/firebase/authRoleService";
 
 import { auth, db } from "@/firebase/firebase";
 
@@ -220,6 +221,7 @@ export default function Navbar() {
   const isActivePath = (href) => pathname === href;
 
   const userRole = accountProfile?.role || "";
+  const canReadManagerNotifications = isStaffRole(userRole);
 
   const profileEmail = accountProfile?.email || currentUser?.email || "Signed in";
 
@@ -478,8 +480,8 @@ export default function Navbar() {
           {currentUser && (
 <div className="flex items-center gap-2 border-l border-[#D7E3D5] pl-3">
 
-              {/* Her integrated Notification Bell */}
-<NotificationBell />
+              {/* Staff-only: clients cannot read manager notification collections. */}
+              {canReadManagerNotifications && <NotificationBell />}
  
               {/* Your User Profile Tag */}
 <div className="flex max-w-[235px] items-center gap-2.5 rounded-full bg-[#EEF4EC] py-1.5 pl-1.5 pr-3 ring-1 ring-[#D7E3D5]">
@@ -549,8 +551,8 @@ export default function Navbar() {
                     )}
 </div>
 
-                  {/* Notification Bell inside Mobile layout */}
-<NotificationBell />
+                  {/* Staff-only: clients cannot read manager notification collections. */}
+                  {canReadManagerNotifications && <NotificationBell />}
 </div>
 <button
 

--- a/frontend/src/components/NavigationProvider/NavigationContext.jsx
+++ b/frontend/src/components/NavigationProvider/NavigationContext.jsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { collection, onSnapshot } from "firebase/firestore";
 import { auth, db, isFirebaseInitialized } from "@/firebase/firebase";
+import { getAccountForUser, isStaffRole } from "@/firebase/authRoleService";
 
 // Create the global Context object for navigation settings.
 const NavigationContext = createContext(null);
@@ -38,7 +39,7 @@ export function NavigationProvider({ children }) {
 
     // Wait for Firebase Auth to restore the session before reading navigation permissions.
     // This avoids unauthenticated reads against Firestore rules that may require a signed-in user.
-    const unsubscribeFromAuth = onAuthStateChanged(auth, (user) => {
+    const unsubscribeFromAuth = onAuthStateChanged(auth, async (user) => {
       stopLinksSubscription();
       setLinksError("");
 
@@ -49,6 +50,16 @@ export function NavigationProvider({ children }) {
       }
 
       setIsLoadingLinks(true);
+
+      const account = await getAccountForUser(user);
+
+      if (!isStaffRole(account?.role)) {
+        // Clients and regular users cannot read manager navigation_links under
+        // Firestore rules, so keep the provider on local static links for them.
+        setLinks([]);
+        setIsLoadingLinks(false);
+        return;
+      }
 
       // Set up a real-time snapshot listener on the navigation_links collection.
       // This allows permission changes in the Admin panel to update active clients without a page refresh.
@@ -88,6 +99,7 @@ export function NavigationProvider({ children }) {
     <NavigationContext.Provider
       value={{
         links,
+        setLinks,
         isLoadingLinks,
         linksError,
       }}

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.jsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useNavigation } from "@/components/NavigationProvider/NavigationContext";
 import { auth, db } from "@/firebase/firebase";
+import { isClientRole } from "@/firebase/authRoleService";
 
 // Wraps protected route groups and blocks rendering until Firebase confirms auth.
 export default function ProtectedRoute({ children }) {
@@ -17,6 +18,7 @@ export default function ProtectedRoute({ children }) {
 
   // Prevents protected content from flashing before auth and role checks finish.
   const [authorizedPath, setAuthorizedPath] = useState(null);
+  const [isRedirecting, setIsRedirecting] = useState(false);
 
   useEffect(() => {
     // If our dynamic navigation layout state is still resolving its connection to Firestore, 
@@ -26,12 +28,18 @@ export default function ProtectedRoute({ children }) {
     }
 
     let shouldIgnore = false;
+    const redirectTo = (href) => {
+      // Marking redirects explicitly keeps protected children unmounted while
+      // Next.js transitions away, avoiding unauthorized Firestore queries.
+      setIsRedirecting(true);
+      router.replace(href);
+    };
 
     // onAuthStateChanged fires after Firebase finishes checking persisted auth.
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (!user) {
         // Unauthenticated users are sent to the login page.
-        router.replace("/");
+        redirectTo("/");
         return;
       }
 
@@ -41,7 +49,7 @@ export default function ProtectedRoute({ children }) {
         const refreshedUser = auth.currentUser || currentAuthUser;
 
         if (!refreshedUser.emailVerified) {
-          router.replace("/?emailNotVerified=1");
+          redirectTo("/?emailNotVerified=1");
           return;
         }
 
@@ -61,12 +69,19 @@ export default function ProtectedRoute({ children }) {
           });
 
           if (!shouldIgnore && pathname !== "/home") {
-            router.replace("/home");
+            redirectTo("/home");
             return;
           }
         }
 
         if (shouldIgnore) {
+          return;
+        }
+
+        if (isClientRole(userRole)) {
+          // Client accounts are intentionally isolated from the manager route
+          // group; the form route resolves their own clientId from accounts/{uid}.
+          redirectTo("/onboarding");
           return;
         }
 
@@ -80,24 +95,25 @@ export default function ProtectedRoute({ children }) {
           // If a configuration exists, enforce the roles checklist matching matrix rules
           const isAllowed = currentRoutePolicy.allowedRoles?.includes(userRole);
           if (!isAllowed) {
-            router.replace("/home?accessDenied=1");
+            redirectTo("/home?accessDenied=1");
             return;
           }
         } else {
           // Fallback security defense layer: If an admin explicitly deleted a link doc from Firestore, 
           // default to letting only an Admin look at it, or handle public fallback paths if needed.
           if (userRole !== "Admin" && pathname.startsWith("/admin")) {
-            router.replace("/home?accessDenied=1");
+            redirectTo("/home?accessDenied=1");
             return;
           }
         }
 
+        setIsRedirecting(false);
         setAuthorizedPath(pathname);
       } catch (error) {
         console.error("Failed to verify route permissions:", error);
 
         if (!shouldIgnore) {
-          router.replace("/home?accessDenied=1");
+          redirectTo("/home?accessDenied=1");
         }
       }
     });
@@ -108,7 +124,7 @@ export default function ProtectedRoute({ children }) {
     };
   }, [pathname, router, links, isLoadingLinks]);
 
-  if (isLoadingLinks || authorizedPath !== pathname) {
+  if (isLoadingLinks || isRedirecting || authorizedPath !== pathname) {
     // Keep a neutral loading state while auth and links context are still being resolved.
     return (
       <main className="flex min-h-screen items-center justify-center bg-slate-50 px-6">

--- a/frontend/src/components/Signup/Signup.jsx
+++ b/frontend/src/components/Signup/Signup.jsx
@@ -1,15 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   createUserWithEmailAndPassword,
   GoogleAuthProvider,
+  onAuthStateChanged,
   sendEmailVerification,
   signInWithPopup,
 } from "firebase/auth";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { auth } from "@/firebase/firebase";
+import {
+  CLIENT_EMAIL_VERIFICATION_PATH,
+  claimClientInviteForUser,
+  getInviteTokenFromCurrentUrl,
+  getPostLoginRedirect,
+} from "@/firebase/authRoleService";
 import {
   getPasswordRequirementResults,
   isPasswordValid,
@@ -94,6 +101,30 @@ export default function Signup() {
     formData.password,
   );
 
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (!user) {
+        return;
+      }
+
+      await user.reload();
+      const refreshedUser = auth.currentUser || user;
+
+      if (!refreshedUser.emailVerified) {
+        setSignupError(
+          "Please verify your email address before continuing to onboarding.",
+        );
+        return;
+      }
+
+      // A verified user refreshing /signup should leave the auth surface and
+      // land wherever their Firestore account role allows.
+      router.replace(await getPostLoginRedirect(refreshedUser));
+    });
+
+    return unsubscribe;
+  }, [router]);
+
   // Converts Firebase and custom registration errors into user-facing messages.
   const getFirebaseErrorMessage = (error) => {
     switch (error.code) {
@@ -159,10 +190,25 @@ export default function Signup() {
         formData.password,
       );
 
+      const inviteToken = getInviteTokenFromCurrentUrl();
+
       try {
         await sendEmailVerification(auth.currentUser || userCredential.user);
       } catch (verificationError) {
         console.error("Failed to send verification email:", verificationError);
+      }
+
+      if (inviteToken) {
+        await claimClientInviteForUser(userCredential.user, inviteToken);
+        if (!userCredential.user.emailVerified) {
+          setSignupError(
+            "Account created. Please verify your email address before continuing to onboarding.",
+          );
+          return;
+        }
+
+        router.push("/onboarding");
+        return;
       }
 
       router.push("/manage-programs");
@@ -181,7 +227,19 @@ export default function Signup() {
     try {
       setIsLoading(true);
 
-      await signInWithPopup(auth, provider);
+      const result = await signInWithPopup(auth, provider);
+      const inviteToken = getInviteTokenFromCurrentUrl();
+
+      if (inviteToken) {
+        await claimClientInviteForUser(result.user, inviteToken);
+        router.push(
+          result.user.emailVerified
+            ? "/onboarding"
+            : CLIENT_EMAIL_VERIFICATION_PATH,
+        );
+        return;
+      }
+
       router.push("/manage-programs");
     } catch (error) {
       setSignupError(getFirebaseErrorMessage(error));

--- a/frontend/src/components/clients/dashboard/ClientProfileDashboard.tsx
+++ b/frontend/src/components/clients/dashboard/ClientProfileDashboard.tsx
@@ -1,17 +1,12 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { User } from "firebase/auth";
+import { toast } from "sonner";
 import { auth } from "@/firebase/firebase";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
-import ProfileTab from "@/components/clients/tabs/ProfileTab";
-import MedicalTab from "@/components/clients/tabs/MedicalTab";
-import ContactsTab from "@/components/clients/tabs/ContactsTab";
-import FinancialAidTab from "@/components/clients/tabs/FinancialAidTab";
-import DocumentsTab from "@/components/clients/tabs/DocumentsTab";
-import LogisticsTab from "@/components/clients/tabs/LogisticsTab";
-import QuestionnaireTab from "@/components/clients/tabs/QuestionnaireTab";
-import LegalConsentsTab from "@/components/clients/tabs/LegalConsentsTab";
+import ClientDataForm from "@/components/clients/forms/ClientDataForm";
 import { QuickCopy } from "@/components/ui/QuickCopy";
 import { IconPencil, IconLock, IconEye } from "@/components/ui/Icons";
 import ProfileSummaryDashboard from "./ProfileSummaryDashboard";
@@ -19,39 +14,10 @@ import AdvancedSettings from "./AdvancedSettings";
 import ProfileArchiveModal from "./ProfileArchiveModal";
 import StatusConfirmationModal from "./StatusConfirmationModal";
 import { useProfileDashboard } from "./useProfileDashboard"; // Our new orchestrator hook
-import { updateClientStatus } from "@/application/ClientManagementService";
-
-// ─── Tab configuration ────────────────────────────────────────────────────────
-
-export const TABS = [
-  { id: "profile", label: "Profile & Demographics" },
-  { id: "medical", label: "Medical" },
-  { id: "contacts", label: "Contacts" },
-  { id: "logistics", label: "Logistics" },
-  { id: "questionnaire", label: "Questionnaire" },
-  { id: "legal", label: "Legal Consents" },
-  { id: "documents", label: "Documents" },
-  { id: "financial", label: "Financial Aid" },
-] as const;
-
-export type TabId = (typeof TABS)[number]["id"];
-
-interface BaseTabProps {
-  client: ClientDoc;
-  isEditable?: boolean;
-  onBack?: () => void;
-}
-
-const TAB_COMPONENTS: Record<TabId, React.ComponentType<BaseTabProps>> = {
-  profile: ProfileTab as React.ComponentType<BaseTabProps>,
-  medical: MedicalTab as React.ComponentType<BaseTabProps>,
-  contacts: ContactsTab as React.ComponentType<BaseTabProps>,
-  logistics: LogisticsTab as React.ComponentType<BaseTabProps>,
-  questionnaire: QuestionnaireTab as React.ComponentType<BaseTabProps>,
-  legal: LegalConsentsTab as React.ComponentType<BaseTabProps>,
-  documents: DocumentsTab as React.ComponentType<BaseTabProps>,
-  financial: FinancialAidTab as React.ComponentType<BaseTabProps>,
-};
+import {
+  createClientInviteLink,
+  updateClientStatus,
+} from "@/application/ClientManagementService";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -60,14 +26,26 @@ interface ClientProfileDashboardProps {
   onBack: () => void;
 }
 
+type AuthUserWithProfile = User & {
+  first_name?: string;
+  last_name?: string;
+};
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function ClientProfileDashboard({ client: initialClient, onBack }: ClientProfileDashboardProps) {
-  const [client, setClient] = useState<ClientDoc>(initialClient);
+  const [statusOverride, setStatusOverride] = useState<{
+    clientId: string;
+    status: ClientDoc["status"];
+  } | null>(null);
 
-  useEffect(() => {
-    setClient(initialClient);
-  }, [initialClient]);
+  // Keep Firestore data as the base record and overlay only the locally saved
+  // status. This avoids a React 19 prop-to-state effect while preserving the
+  // immediate status badge update after a successful transition.
+  const client: ClientDoc =
+    statusOverride?.clientId === initialClient.id
+      ? { ...initialClient, status: statusOverride.status }
+      : initialClient;
 
   // Consume all Tier 2 side effects, async operations, and state variables via the hook
   const {
@@ -90,6 +68,9 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
   // ── Status badge state ───────────────────────────────────────────────────
   const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+  const [inviteLink, setInviteLink] = useState("");
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [isCopyingInvite, setIsCopyingInvite] = useState(false);
 
   async function handleStatusChange() {
     const clientName = `${client.first_name ?? ""} ${client.last_name ?? ""}`.trim();
@@ -97,7 +78,7 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
     const newStatus = client.status === "registered" ? "interested" : "registered";
     setIsUpdatingStatus(true);
     try {
-      const user = auth?.currentUser as any;
+      const user = auth?.currentUser as AuthUserWithProfile | null;
       let managerName = "Unknown";
       if (user?.first_name && user?.last_name) {
         managerName = `${user.first_name} ${user.last_name}`;
@@ -106,9 +87,25 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
       }
 
       await updateClientStatus(client.id, clientName, newStatus, managerName);
-      setClient((prev) => ({ ...prev, status: newStatus }));
+      setStatusOverride({ clientId: client.id, status: newStatus });
+
+      if (newStatus === "registered" && typeof window !== "undefined") {
+        try {
+          // Registration now completes the invite workflow: once the status write
+          // succeeds, create the pending invite and show the copyable signup URL.
+          const generatedLink = await createClientInviteLink(
+            client.id,
+            window.location.origin,
+          );
+          setInviteLink(generatedLink);
+          setIsInviteModalOpen(true);
+        } catch (error) {
+          console.error("[ClientProfileDashboard] invite generation failed:", error);
+          toast.error("Registration completed, but the invite link could not be generated.");
+        }
+      }
     } catch {
-      // Toast already fired by the service layer
+      // Status service owns the user-facing failure toast.
     } finally {
       setIsUpdatingStatus(false);
       setIsStatusModalOpen(false);
@@ -125,6 +122,20 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
     });
     router.push(`/events?${queryParams.toString()}`);
   };
+
+  async function handleCopyInviteLink() {
+    if (!inviteLink) return;
+
+    setIsCopyingInvite(true);
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      toast.success("Invite link copied to clipboard.");
+    } catch {
+      toast.error("Could not copy the invite link. Please copy it manually.");
+    } finally {
+      setIsCopyingInvite(false);
+    }
+  }
 
   const initials = `${client.first_name?.[0] || ""}${client.last_name?.[0] || ""}`.toUpperCase();
 
@@ -269,52 +280,13 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
 
         {/* ── View Switcher ── */}
         {showDetailedTabs ? (
-          <>
-            <nav aria-label="Client profile sections" className="overflow-x-auto rounded-2xl border border-white/80 bg-[#FFFDF8] p-2 shadow-[0_10px_25px_rgba(44,105,117,0.06)]">
-              <ol role="tablist" className="flex min-w-max gap-1.5">
-                {TABS.map((tab) => {
-                  const isActive = tab.id === activeTab;
-                  return (
-                    <li key={tab.id} role="presentation">
-                      <button
-                        role="tab"
-                        id={`tab-${tab.id}`}
-                        aria-selected={isActive}
-                        aria-controls={`tabpanel-${tab.id}`}
-                        type="button"
-                        onClick={() => setActiveTab(tab.id)}
-                        className={[
-                          "whitespace-nowrap rounded-xl px-4 py-2.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6BB2A0]",
-                          isActive
-                            ? "bg-[#DCEBEF] text-[#245C66] ring-1 ring-[#C9DDE1]"
-                            : "text-[#607B80] hover:bg-[#EEF4EC] hover:text-[#31585F]",
-                        ].join(" ")}
-                      >
-                        {tab.label}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ol>
-            </nav>
-
-            <fieldset className="min-w-0 rounded-[1.75rem] border border-white/80 bg-[#FFFDF8] p-4 shadow-[0_14px_34px_rgba(44,105,117,0.08)] sm:p-6">
-              <div role="tabpanel" id={`tabpanel-${activeTab}`} aria-labelledby={`tab-${activeTab}`}>
-                {(() => {
-                  const ActiveTabContent = TAB_COMPONENTS[activeTab];
-                  if (!ActiveTabContent) return null;
-
-                  return (
-                    <ActiveTabContent
-                      client={client}
-                      isEditable={effectiveEditable}
-                      onBack={activeTab === "profile" ? onBack : undefined}
-                    />
-                  );
-                })()}
-              </div>
-            </fieldset>
-          </>
+          <ClientDataForm
+            client={client}
+            isEditable={effectiveEditable}
+            activeTab={activeTab}
+            onActiveTabChange={setActiveTab}
+            onBack={onBack}
+          />
         ) : (
           <ProfileSummaryDashboard 
              client={client} 
@@ -322,7 +294,6 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
              onCreateMeeting={handleCreateMeetingNavigation} 
           />
         )}
-
         {/* ── Advanced Settings ── */}
         <AdvancedSettings 
           isArchived={isArchived} 
@@ -350,6 +321,59 @@ export default function ClientProfileDashboard({ client: initialClient, onBack }
             if (!isUpdatingStatus) setIsStatusModalOpen(false);
           }}
         />
+      )}
+
+      {isInviteModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#15383E]/70 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-xl rounded-[1.75rem] border border-white/50 bg-[#FFFDF8] p-6 shadow-[0_24px_60px_rgba(21,56,62,0.28)]">
+            <div className="mb-5 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-lg font-bold text-[#15383E]">
+                  Client Invite Link
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-[#607B80]">
+                  Share this signup link with {client.first_name || "the client"}.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsInviteModalOpen(false)}
+                className="flex h-8 w-8 items-center justify-center rounded-full text-xl font-bold text-[#6A8589] transition hover:bg-[#EEF4EC] hover:text-[#173A40]"
+                aria-label="Close invite link dialog"
+              >
+                &times;
+              </button>
+            </div>
+
+            <label className="mb-2 block text-xs font-bold uppercase tracking-[0.12em] text-[#6A8589]">
+              Signup URL
+            </label>
+            <textarea
+              readOnly
+              value={inviteLink}
+              rows={3}
+              className="mb-4 w-full resize-none rounded-2xl border border-[#BFD0CA] bg-white px-4 py-3 text-sm leading-6 text-[#31585F] outline-none focus:border-[#6BB2A0] focus:ring-4 focus:ring-[#D7E7D4]"
+            />
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={() => setIsInviteModalOpen(false)}
+                className="rounded-full border border-[#BFD0CA] bg-white px-4 py-2 text-sm font-bold text-[#31585F] transition hover:bg-[#EEF4EC]"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={handleCopyInviteLink}
+                disabled={isCopyingInvite || !inviteLink}
+                className="rounded-full bg-[#245C66] px-5 py-2 text-sm font-bold text-white transition hover:bg-[#173A40] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isCopyingInvite ? "Copying..." : "Copy to Clipboard"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/clients/dashboard/ProfileSummaryDashboard.tsx
+++ b/frontend/src/components/clients/dashboard/ProfileSummaryDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { User } from "firebase/auth";
 import { IconCheck } from "@/components/ui/Icons";
 import { auth } from "@/firebase/firebase";
 
@@ -19,6 +20,11 @@ interface ProfileSummaryDashboardProps {
   isArchived: boolean;
   onCreateMeeting?: () => void; // We keep this for backward compatibility, but we won't use it for the button anymore
 }
+
+type AuthUserWithProfile = User & {
+  first_name?: string;
+  last_name?: string;
+};
 
 export default function ProfileSummaryDashboard({ client, isArchived }: ProfileSummaryDashboardProps) {
   // ── UI State (Tier 1) ────────────────────────────────────────────────────────
@@ -54,7 +60,10 @@ export default function ProfileSummaryDashboard({ client, isArchived }: ProfileS
     try {
       const clientName = `${client.first_name ?? ""} ${client.last_name ?? ""}`.trim();
       
-      const user = auth?.currentUser as any;
+      // Firebase Auth's base User type does not include the optional profile
+      // fields some app flows attach, so this local extension keeps access
+      // explicit without falling back to `any`.
+      const user = auth?.currentUser as AuthUserWithProfile | null;
       let authorName = "Unknown";
       if (user?.first_name && user?.last_name) {
         authorName = `${user.first_name} ${user.last_name}`;

--- a/frontend/src/components/clients/dashboard/useProfileDashboard.ts
+++ b/frontend/src/components/clients/dashboard/useProfileDashboard.ts
@@ -4,10 +4,10 @@ import { useState } from "react";
 import { type ClientDoc } from "@/components/clients/list/ClientList";
 import { restoreClientInDb, archiveClientInDb } from "@/firebase/clientDbService";
 import { toast } from "sonner";
-import { type TabId } from "./ClientProfileDashboard";
+import { type ClientDataFormTabId } from "@/components/clients/forms/ClientDataForm";
 
 export function useProfileDashboard(client: ClientDoc) {
-  const [activeTab, setActiveTab] = useState<TabId>("profile");
+  const [activeTab, setActiveTab] = useState<ClientDataFormTabId>("profile");
   const [isEditable, setIsEditable] = useState(false);
   const [showDetailedTabs, setShowDetailedTabs] = useState(false);
   const [localIsArchived, setLocalIsArchived] = useState(client.is_archived === true);

--- a/frontend/src/components/clients/forms/ClientDataForm.tsx
+++ b/frontend/src/components/clients/forms/ClientDataForm.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import type { ComponentType } from "react";
+import type { ClientDoc } from "@/components/clients/list/ClientList";
+import ProfileTab from "@/components/clients/tabs/ProfileTab";
+import MedicalTab from "@/components/clients/tabs/MedicalTab";
+import ContactsTab from "@/components/clients/tabs/ContactsTab";
+import FinancialAidTab from "@/components/clients/tabs/FinancialAidTab";
+import DocumentsTab from "@/components/clients/tabs/DocumentsTab";
+import LogisticsTab from "@/components/clients/tabs/LogisticsTab";
+import QuestionnaireTab from "@/components/clients/tabs/QuestionnaireTab";
+import LegalConsentsTab from "@/components/clients/tabs/LegalConsentsTab";
+
+export const CLIENT_DATA_FORM_TABS = [
+  { id: "profile", label: "Profile & Demographics" },
+  { id: "medical", label: "Medical" },
+  { id: "contacts", label: "Contacts" },
+  { id: "logistics", label: "Logistics" },
+  { id: "questionnaire", label: "Questionnaire" },
+  { id: "legal", label: "Legal Consents" },
+  { id: "documents", label: "Documents" },
+  { id: "financial", label: "Financial Aid" },
+] as const;
+
+export type ClientDataFormTabId = (typeof CLIENT_DATA_FORM_TABS)[number]["id"];
+
+interface BaseTabProps {
+  client: ClientDoc;
+  isEditable?: boolean;
+  onBack?: () => void;
+}
+
+const TAB_COMPONENTS: Record<ClientDataFormTabId, ComponentType<BaseTabProps>> = {
+  profile: ProfileTab as ComponentType<BaseTabProps>,
+  medical: MedicalTab as ComponentType<BaseTabProps>,
+  contacts: ContactsTab as ComponentType<BaseTabProps>,
+  logistics: LogisticsTab as ComponentType<BaseTabProps>,
+  questionnaire: QuestionnaireTab as ComponentType<BaseTabProps>,
+  legal: LegalConsentsTab as ComponentType<BaseTabProps>,
+  documents: DocumentsTab as ComponentType<BaseTabProps>,
+  financial: FinancialAidTab as ComponentType<BaseTabProps>,
+};
+
+interface ClientDataFormProps {
+  client: ClientDoc;
+  isEditable: boolean;
+  activeTab?: ClientDataFormTabId;
+  onActiveTabChange?: (tabId: ClientDataFormTabId) => void;
+  onBack?: () => void;
+}
+
+/**
+ * Shared client data form shell.
+ *
+ * This component owns only the tab navigation and tab rendering surface. The
+ * individual tab controllers keep their existing validation and Firestore save
+ * behavior, allowing the manager edit view and client onboarding route to reuse
+ * the exact same form implementation.
+ */
+export default function ClientDataForm({
+  client,
+  isEditable,
+  activeTab,
+  onActiveTabChange,
+  onBack,
+}: ClientDataFormProps) {
+  const [internalActiveTab, setInternalActiveTab] =
+    useState<ClientDataFormTabId>("profile");
+  const resolvedActiveTab = activeTab ?? internalActiveTab;
+  const ActiveTabContent = TAB_COMPONENTS[resolvedActiveTab];
+
+  function handleTabChange(tabId: ClientDataFormTabId) {
+    if (onActiveTabChange) {
+      onActiveTabChange(tabId);
+      return;
+    }
+
+    setInternalActiveTab(tabId);
+  }
+
+  return (
+    <>
+      <nav
+        aria-label="Client profile sections"
+        className="overflow-x-auto rounded-2xl border border-white/80 bg-[#FFFDF8] p-2 shadow-[0_10px_25px_rgba(44,105,117,0.06)]"
+      >
+        <ol role="tablist" className="flex min-w-max gap-1.5">
+          {CLIENT_DATA_FORM_TABS.map((tab) => {
+            const isActive = tab.id === resolvedActiveTab;
+            return (
+              <li key={tab.id} role="presentation">
+                <button
+                  role="tab"
+                  id={`tab-${tab.id}`}
+                  aria-selected={isActive}
+                  aria-controls={`tabpanel-${tab.id}`}
+                  type="button"
+                  onClick={() => handleTabChange(tab.id)}
+                  className={[
+                    "whitespace-nowrap rounded-xl px-4 py-2.5 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6BB2A0]",
+                    isActive
+                      ? "bg-[#DCEBEF] text-[#245C66] ring-1 ring-[#C9DDE1]"
+                      : "text-[#607B80] hover:bg-[#EEF4EC] hover:text-[#31585F]",
+                  ].join(" ")}
+                >
+                  {tab.label}
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <fieldset className="min-w-0 rounded-[1.75rem] border border-white/80 bg-[#FFFDF8] p-4 shadow-[0_14px_34px_rgba(44,105,117,0.08)] sm:p-6">
+        <div
+          role="tabpanel"
+          id={`tabpanel-${resolvedActiveTab}`}
+          aria-labelledby={`tab-${resolvedActiveTab}`}
+        >
+          <ActiveTabContent
+            client={client}
+            isEditable={isEditable}
+            onBack={resolvedActiveTab === "profile" ? onBack : undefined}
+          />
+        </div>
+      </fieldset>
+    </>
+  );
+}

--- a/frontend/src/firebase/authRoleService.js
+++ b/frontend/src/firebase/authRoleService.js
@@ -1,0 +1,172 @@
+import { doc, getDoc, runTransaction, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/firebase/firebase";
+
+const CLIENT_ROLES = new Set(["client", "Client"]);
+const STAFF_ROLES = new Set(["Admin", "Program Manager"]);
+const MANAGER_FALLBACK_PATH = "/home";
+const CLIENT_ONBOARDING_PATH = "/onboarding";
+export const CLIENT_EMAIL_VERIFICATION_PATH = "/login?emailNotVerified=1";
+
+function requireFirestore() {
+  if (!db) {
+    throw new Error("Firestore is not initialized.");
+  }
+
+  return db;
+}
+
+function normalizeRole(role) {
+  return typeof role === "string" ? role.trim() : "";
+}
+
+export function isClientRole(role) {
+  return CLIENT_ROLES.has(normalizeRole(role));
+}
+
+export function isStaffRole(role) {
+  return STAFF_ROLES.has(normalizeRole(role));
+}
+
+/**
+ * Reads the signed-in user's canonical account profile. Account records are the
+ * role source of truth for route decisions and client profile ownership.
+ */
+export async function getAccountForUser(user) {
+  if (!user) return null;
+
+  const activeDb = requireFirestore();
+  const accountSnapshot = await getDoc(doc(activeDb, "accounts", user.uid));
+
+  if (!accountSnapshot.exists()) {
+    return null;
+  }
+
+  return {
+    id: accountSnapshot.id,
+    ...accountSnapshot.data(),
+  };
+}
+
+/**
+ * Keeps Admin account tables current for every successful auth flow.
+ * Uses Firestore Timestamp via serverTimestamp(), matching the existing
+ * created_at/last_login rendering expectations in the admin dashboard.
+ */
+export async function stampAccountLogin(user) {
+  if (!user) return;
+
+  const activeDb = requireFirestore();
+  await setDoc(
+    doc(activeDb, "accounts", user.uid),
+    {
+      account_id: user.uid,
+      email: user.email || "",
+      last_login: serverTimestamp(),
+      updated_at: serverTimestamp(),
+    },
+    { merge: true },
+  );
+}
+
+/**
+ * Reads the canonical account profile and returns the route users should land on
+ * after authentication. Missing account profiles keep the historical manager
+ * fallback so existing staff login behavior remains stable.
+ */
+export async function getPostLoginRedirect(user) {
+  const account = await getAccountForUser(user);
+
+  if (!account) {
+    return MANAGER_FALLBACK_PATH;
+  }
+
+  await stampAccountLogin(user);
+
+  if (!isClientRole(account.role)) {
+    return MANAGER_FALLBACK_PATH;
+  }
+
+  // Client onboarding is blocked until Firebase Auth confirms the email.
+  // Manager/admin fallback behavior stays unchanged because this gate applies
+  // only after the canonical Firestore role is known to be a client role.
+  return user.emailVerified
+    ? CLIENT_ONBOARDING_PATH
+    : CLIENT_EMAIL_VERIFICATION_PATH;
+}
+
+/**
+ * Supports invite links such as /signup?inviteToken=abc, /signup?invite=abc, or
+ * /signup?token=abc without committing to one URL shape before the email-link
+ * flow is finalized.
+ */
+export function getInviteTokenFromCurrentUrl() {
+  if (typeof window === "undefined") return "";
+
+  const params = new URLSearchParams(window.location.search);
+  return (
+    params.get("inviteToken") ||
+    params.get("invite") ||
+    params.get("token") ||
+    ""
+  ).trim();
+}
+
+/**
+ * Claims an existing manager-created client invite for the signed-in Firebase
+ * user. The matching Firestore rules require this account write, invite update,
+ * and client uid update to succeed together, preventing arbitrary clientId
+ * self-assignment from the browser.
+ */
+export async function claimClientInviteForUser(user, inviteToken) {
+  if (!user || !inviteToken) return null;
+
+  const activeDb = requireFirestore();
+  const inviteRef = doc(activeDb, "client_invites", inviteToken);
+  const accountRef = doc(activeDb, "accounts", user.uid);
+
+  return runTransaction(activeDb, async (transaction) => {
+    const inviteSnapshot = await transaction.get(inviteRef);
+
+    if (!inviteSnapshot.exists()) {
+      throw new Error("This invite link is invalid or expired.");
+    }
+
+    const invite = inviteSnapshot.data();
+
+    if (invite.status && invite.status !== "pending") {
+      throw new Error("This invite link has already been used.");
+    }
+
+    if (!invite.clientId || typeof invite.clientId !== "string") {
+      throw new Error("This invite link is missing a client record.");
+    }
+
+    const clientRef = doc(activeDb, "clients", invite.clientId);
+    transaction.set(
+      accountRef,
+      {
+        account_id: user.uid,
+        email: user.email || "",
+        role: "client",
+        clientId: invite.clientId,
+        clientInviteToken: inviteToken,
+        last_login: serverTimestamp(),
+        updated_at: serverTimestamp(),
+      },
+      { merge: true },
+    );
+
+    transaction.update(inviteRef, {
+      status: "claimed",
+      claimedByUid: user.uid,
+      claimedAt: serverTimestamp(),
+    });
+
+    transaction.update(clientRef, {
+      uid: user.uid,
+      updated_at: serverTimestamp(),
+    });
+
+    return invite.clientId;
+  });
+}

--- a/frontend/src/firebase/clientDbService.ts
+++ b/frontend/src/firebase/clientDbService.ts
@@ -1,5 +1,5 @@
-import { doc, updateDoc, serverTimestamp, collection, onSnapshot, query, orderBy, getDocs, writeBatch, arrayUnion, arrayRemove, addDoc } from "firebase/firestore";
-import { db, storage } from "@/firebase/firebase";
+import { doc, updateDoc, serverTimestamp, collection, onSnapshot, query, orderBy, getDocs, writeBatch, arrayUnion, arrayRemove, addDoc, setDoc, getDoc } from "firebase/firestore";
+import { auth, db, storage } from "@/firebase/firebase";
 import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
 
@@ -13,6 +13,19 @@ export function getFirestoreDb() {
 export function getFirebaseStorage() {
   if (!storage) throw new Error("Firebase Storage is not initialized.");
   return storage;
+}
+
+async function isCurrentUserClientRole(): Promise<boolean> {
+  const user = auth?.currentUser;
+
+  if (!user) {
+    return false;
+  }
+
+  const accountSnapshot = await getDoc(doc(getFirestoreDb(), "accounts", user.uid));
+  const role = accountSnapshot.exists() ? accountSnapshot.data().role : "";
+
+  return role === "client" || role === "Client";
 }
 
 // ─── Utility ──────────────────────────────────────────────────────────────────
@@ -31,6 +44,43 @@ export function sanitizeFirestorePayload(obj: Record<string, any>): Record<strin
         }
         return [k, v];
       })
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function pickClientEditableFields(payload: Record<string, any>): Record<string, any> {
+  const clientEditableFields = new Set([
+    "first_name",
+    "last_name",
+    "email",
+    "phone",
+    "passport_id",
+    "gender",
+    "address",
+    "dob",
+    "referrer",
+    "education_status",
+    "diagnosis",
+    "personal_notes",
+    "passport_number",
+    "passport_country",
+    "citizenship",
+    "date_of_entry",
+    "purpose_of_visit",
+    "home_address",
+    "cohabitants",
+    "dependents",
+    "medical_profile",
+    "contacts",
+    "logistics",
+    "questionnaire",
+    "legal_consents",
+    "financial_aid_applications",
+    "client_documents",
+  ]);
+
+  return Object.fromEntries(
+    Object.entries(payload).filter(([key]) => clientEditableFields.has(key))
   );
 }
 
@@ -61,7 +111,16 @@ export async function updateClientDoc(
   payload: Record<string, any>
 ): Promise<void> {
   const docRef = doc(getFirestoreDb(), "clients", clientId);
-  
+  const isClientUpdate = await isCurrentUserClientRole();
+
+  if (isClientUpdate) {
+    // Client onboarding writes must be strict patches. Do not send manager-owned
+    // fields or metadata such as status, program_ids, uid, or timestamps because
+    // Firestore rules require those values to remain unchanged for client roles.
+    await updateDoc(docRef, sanitizeFirestorePayload(pickClientEditableFields(payload)));
+    return;
+  }
+
   await updateDoc(docRef, {
     ...sanitizeFirestorePayload(payload),
     updated_at: serverTimestamp(),
@@ -81,6 +140,22 @@ export async function archiveClientInDb(clientId: string): Promise<void> {
   await updateDoc(docRef, {
     is_archived: true,
     updated_at: serverTimestamp(),
+  });
+}
+
+/**
+ * Creates a pending invite token document for a client onboarding link.
+ * The caller supplies the token so the document ID can be embedded in the
+ * manager-facing URL without reading sensitive invite state back from Firestore.
+ */
+export async function createClientInviteDoc(
+  clientId: string,
+  inviteToken: string
+): Promise<void> {
+  await setDoc(doc(getFirestoreDb(), "client_invites", inviteToken), {
+    clientId,
+    status: "pending",
+    created_at: serverTimestamp(),
   });
 }
 

--- a/frontend/src/firebase/googleCalendarService.js
+++ b/frontend/src/firebase/googleCalendarService.js
@@ -82,7 +82,7 @@ export async function ensureGisLoaded() {
             resolve();
           }
         }
-      } catch (e) {
+      } catch {
         reject(new Error("Error while initializing GIS after script load."));
       }
     });


### PR DESCRIPTION
Merged latest updates from `main` and finalized the new **Secure Client Onboarding Flow**. 

---

### 🔄 The New Client Lifecycle
1. **Invite Generation:** When a manager shifts a client's status to `REGISTERED`, the system automatically generates a unique token, creates a `client_invites/{token}` document, and pops up a copyable onboarding link (`/signup?inviteToken={token}`).
2. **Verification Gate:** Newly registered clients are restricted to auth surfaces until they verify their email (`user.emailVerified`). If they try to access `/onboarding` directly, the Route Guard kicks them back to login. 
3. **F5 Safe Hydration:** Once verified, a simple page refresh (F5) automatically routes them into the onboarding form without requiring manual logout/login.
4. **Data Scrubbing:** When a client saves their profile, `updateClientDoc` filters the payload through a strict **Allow-list**. It strips out staff-only metadata (status, program IDs) to prevent privilege escalation and fix Firestore permission errors.

---

### 🛠️ Core Fixes & Integration
* **Merge Regression Fix:** Resolved a runtime `ReferenceError: actionItems is not defined` in `statistic/page.jsx` introduced during the merge from `main`.
* **Admin Telemetry:** Integrated the `client` role into the Admin Accounts table and Permissions grid. Added automatic `last_login` timestamp sync on login.
* **UI Cleanup:** Hid the global navbar, notifications, and staff links from client auth/onboarding routes, and added a minimal **Log Out** button to the onboarding header.