### PR TITLE
refactor: simplify document management and configure storage (closes #59)

### DIFF
--- a/frontend/src/components/clients/tabs/DocumentsTab.tsx
+++ b/frontend/src/components/clients/tabs/DocumentsTab.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 
-import { DOCUMENT_TYPE_OPTIONS, DOCUMENT_STATUS_OPTIONS, type DocumentStatus, type ClientDocument } from "@/schema/documentSchema";
+import { DOCUMENT_TYPE_OPTIONS, type ClientDocument } from "@/schema/documentSchema";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
 
 // Import our Tier 2 Controller
@@ -14,14 +14,6 @@ interface DocumentsTabProps {
   client: ClientDoc;
 }
 
-// ─── Status badge styling ─────────────────────────────────────────────────────
-
-const STATUS_BADGE: Record<DocumentStatus, { bg: string; text: string; border: string }> = {
-  active:         { bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-200" },
-  expired:        { bg: "bg-red-50",     text: "text-red-700",     border: "border-red-200"     },
-  pending_review: { bg: "bg-amber-50",   text: "text-amber-700",   border: "border-amber-200"   },
-  rejected:       { bg: "bg-slate-100",  text: "text-slate-600",   border: "border-slate-200"   },
-};
 
 // ─── Helpers (Pure UI) ────────────────────────────────────────────────────────
 
@@ -40,15 +32,6 @@ function fileIcon(fileName: string) {
   if (ext === "pdf") return "📄";
   if (["jpg", "jpeg", "png", "webp", "heic"].includes(ext ?? "")) return "🖼️";
   return "📎";
-}
-
-function inputCls(hasError: boolean) {
-  return [
-    "w-full rounded-lg border px-3.5 py-2.5 text-sm text-slate-800 outline-none",
-    "placeholder:text-slate-400 transition-colors duration-150",
-    "focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1",
-    hasError ? "border-red-400 bg-red-50 focus:ring-red-400" : "border-slate-300 bg-white hover:border-slate-400",
-  ].join(" ");
 }
 
 function selectCls(hasError: boolean) {
@@ -82,8 +65,6 @@ function FieldWrapper({
 // ─── DocumentRow ──────────────────────────────────────────────────────────────
 
 function DocumentRow({ doc: document, onDelete }: { doc: ClientDocument; onDelete: () => void; }) {
-  const badge = STATUS_BADGE[document.status] ?? STATUS_BADGE.active;
-
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-[#D7E3D5] bg-white px-4 py-4 shadow-sm sm:flex-row sm:items-center">
       <span className="text-xl" aria-hidden="true">{fileIcon(document.file_name)}</span>
@@ -92,15 +73,10 @@ function DocumentRow({ doc: document, onDelete }: { doc: ClientDocument; onDelet
         <p className="truncate text-sm font-bold text-[#173A40]">{document.file_name}</p>
         <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
           <span className="text-xs text-slate-500">{humanize(document.document_type)}</span>
-          {document.expiration_date && <span className="text-xs text-slate-400">Expires: {formatDate(document.expiration_date)}</span>}
           {document.uploaded_at && <span className="text-xs text-slate-400">Uploaded: {formatDate(document.uploaded_at)}</span>}
         </div>
         {document.manager_notes && <p className="mt-1 truncate text-xs text-slate-400 italic">{document.manager_notes}</p>}
       </div>
-
-      <span className={["shrink-0 rounded-full border px-2.5 py-0.5 text-xs font-semibold", badge.bg, badge.text, badge.border].join(" ")}>
-        {humanize(document.status)}
-      </span>
 
       <div className="flex shrink-0 items-center gap-2">
         <a
@@ -123,9 +99,8 @@ function DocumentRow({ doc: document, onDelete }: { doc: ClientDocument; onDelet
 // ─── Main Component (Tier 1: Dumb View) ───────────────────────────────────────
 
 export default function DocumentsTab({ client }: DocumentsTabProps) {
-  // Wire up the controller
   const { form, docs, uploadState, actions } = useDocumentsTabController(client);
-  const { register, handleSubmit, formState: { errors, isSubmitting } } = form;
+  const { formState: { errors, isSubmitting } } = form;
 
   const isUploading = uploadState.isLoading || isSubmitting || uploadState.uploadProgress !== null;
 
@@ -155,14 +130,73 @@ export default function DocumentsTab({ client }: DocumentsTabProps) {
         </div>
       </div>
 
-      {/* ════ Section 2: Upload form ════ */}
-      <form onSubmit={handleSubmit(actions.onSubmit)} noValidate>
-        <div className="overflow-hidden rounded-[1.5rem] border border-[#D7E3D5] bg-white shadow-sm">
-          <div className="border-b border-[#D7E3D5] bg-[#F7FAF5] px-6 py-4 sm:px-8">
-            <h2 className="text-base font-bold text-[#173A40]">Upload New Document</h2>
-            <p className="mt-0.5 text-sm text-slate-500">PDF, JPEG, PNG, WebP, or HEIC · Max 10 MB</p>
-          </div>
+      {/* ════ Section 2: Collapsible upload form ════ */}
+      <UploadSection
+        form={form}
+        errors={errors}
+        isUploading={isUploading}
+        uploadState={uploadState}
+        actions={actions}
+      />
+    </div>
+  );
+}
 
+// ─── UploadSection (isolated collapsible wrapper) ─────────────────────────────
+
+function UploadSection({
+  form,
+  errors,
+  isUploading,
+  uploadState,
+  actions,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  form: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: any;
+  isUploading: boolean;
+  uploadState: {
+    isLoading: boolean;
+    uploadProgress: number | null;
+    fileError: string | null;
+    setFileError: (v: string | null) => void;
+    selectedFile: File | null;
+    setSelectedFile: (v: File | null) => void;
+  };
+  actions: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onSubmit: (data: any) => Promise<void>;
+  };
+}) {
+  const { handleSubmit, register } = form;
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="overflow-hidden rounded-[1.5rem] border border-[#D7E3D5] bg-white shadow-sm">
+      {/* Toggle header */}
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between border-b border-[#D7E3D5] bg-[#F7FAF5] px-6 py-4 sm:px-8 hover:bg-[#EEF4EC] transition-colors"
+        aria-expanded={isOpen}
+      >
+        <div className="text-left">
+          <h2 className="text-base font-bold text-[#173A40]">Upload New Document</h2>
+          <p className="mt-0.5 text-sm text-slate-500">PDF, JPEG, PNG, WebP, or HEIC · Max 10 MB</p>
+        </div>
+        <span
+          className="ml-4 shrink-0 text-lg text-[#2C6975] transition-transform duration-200"
+          style={{ transform: isOpen ? "rotate(180deg)" : "rotate(0deg)" }}
+          aria-hidden="true"
+        >
+          ▾
+        </span>
+      </button>
+
+      {/* Collapsible body */}
+      {isOpen && (
+        <form onSubmit={handleSubmit(actions.onSubmit)} noValidate>
           <div className="space-y-5 p-6 sm:p-8">
             {/* File picker */}
             <div className="flex flex-col gap-1">
@@ -213,7 +247,7 @@ export default function DocumentsTab({ client }: DocumentsTabProps) {
               )}
             </div>
 
-            <div className="grid gap-5 sm:grid-cols-2">
+            <div className="grid gap-5">
               <FieldWrapper label="Document Type" htmlFor="doc-type" error={errors.document_type?.message} required>
                 <select id="doc-type" className={selectCls(!!errors.document_type)} {...register("document_type")}>
                   <option value="">Select type…</option>
@@ -221,12 +255,8 @@ export default function DocumentsTab({ client }: DocumentsTabProps) {
                 </select>
               </FieldWrapper>
 
-              <FieldWrapper label="Expiration Date" htmlFor="doc-expiration" error={errors.expiration_date?.message}>
-                <input id="doc-expiration" type="date" className={inputCls(!!errors.expiration_date)} {...register("expiration_date")} />
-              </FieldWrapper>
-
-              <div className="sm:col-span-2">
-                <FieldWrapper label="Manager Notes" htmlFor="doc-notes" error={errors.manager_notes?.message}>
+              <div>
+                <FieldWrapper label="Notes" htmlFor="doc-notes" error={errors.manager_notes?.message}>
                   <textarea
                     id="doc-notes" rows={3} placeholder="Any context about this document (optional)"
                     className={[
@@ -266,21 +296,8 @@ export default function DocumentsTab({ client }: DocumentsTabProps) {
               {isUploading ? "Uploading…" : "Upload Document"}
             </button>
           </div>
-        </div>
-      </form>
-
-      {/* ════ Section 3: Status legend ════ */}
-      <div className="flex flex-wrap gap-3 px-1">
-        <p className="w-full text-xs font-semibold text-slate-400 uppercase tracking-wide">Status legend</p>
-        {DOCUMENT_STATUS_OPTIONS.map((s) => {
-          const b = STATUS_BADGE[s];
-          return (
-            <span key={s} className={["rounded-full border px-2.5 py-0.5 text-xs font-semibold", b.bg, b.text, b.border].join(" ")}>
-              {humanize(s)}
-            </span>
-          );
-        })}
-      </div>
+        </form>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/clients/tabs/controllers/DocumentsTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/DocumentsTabController.ts
@@ -43,7 +43,6 @@ export function useDocumentsTabController(client: ClientDoc) {
     mode: "onTouched",
     defaultValues: {
       document_type: undefined,
-      expiration_date: "",
       manager_notes: "",
     },
   });
@@ -89,9 +88,7 @@ export function useDocumentsTabController(client: ClientDoc) {
         document_type: formData.document_type,
         file_name: file.name,
         file_url: downloadURL,
-        status: "active",
         uploaded_at: new Date().toISOString().split("T")[0],
-        expiration_date: formData.expiration_date ?? "",
         manager_notes: formData.manager_notes ?? "",
       };
 

--- a/frontend/src/components/dashboard/ManagerDashboardShell.tsx
+++ b/frontend/src/components/dashboard/ManagerDashboardShell.tsx
@@ -28,7 +28,6 @@ import { db } from "@/firebase/firebase";
 import {
   basicInfoSchema,
   CLIENT_STATUS,
-  DOCUMENT_STATUS_OPTIONS,
   MEDICAL_CLEARANCE_STATUS,
 } from "@/schema/clientSchema";
 
@@ -87,7 +86,7 @@ const dashboardClientSchema = z.object({
   client_documents: z
     .array(
       z.object({
-        status: z.enum(DOCUMENT_STATUS_OPTIONS),
+        status: z.string().optional(),
       }).passthrough(),
     )
     .optional(),

--- a/frontend/src/schema/clientSchema.ts
+++ b/frontend/src/schema/clientSchema.ts
@@ -188,7 +188,6 @@ export type {
 // From Document Domain
 export { 
   DOCUMENT_TYPE_OPTIONS, 
-  DOCUMENT_STATUS_OPTIONS, 
   clientDocumentSchema, 
   uploadDocumentFormSchema 
 } from "../schema/documentSchema";

--- a/frontend/src/schema/documentSchema.ts
+++ b/frontend/src/schema/documentSchema.ts
@@ -17,28 +17,19 @@ export const DOCUMENT_TYPE_OPTIONS = [
 ] as const;
 export type DocumentType = (typeof DOCUMENT_TYPE_OPTIONS)[number];
 
-export const DOCUMENT_STATUS_OPTIONS = [
-  "active",
-  "expired",
-  "pending_review",
-  "rejected",
-] as const;
-export type DocumentStatus = (typeof DOCUMENT_STATUS_OPTIONS)[number];
 
 /**
  * One uploaded document entry.
  * Stored as an array `client_documents[]` on the client Firestore document.
  */
 export const clientDocumentSchema = z.object({
-  document_type:   z.enum(DOCUMENT_TYPE_OPTIONS, {
+  document_type: z.enum(DOCUMENT_TYPE_OPTIONS, {
     errorMap: () => ({ message: "Please select a document type" }),
   }),
-  file_name:       z.string().min(1),
-  file_url:        z.string().url("Invalid file URL"),
-  status:          z.enum(DOCUMENT_STATUS_OPTIONS).default("active"),
-  uploaded_at:     z.string().optional().or(z.literal("")),
-  expiration_date: z.string().optional().or(z.literal("")),
-  manager_notes:   z
+  file_name:    z.string().min(1),
+  file_url:     z.string().url("Invalid file URL"),
+  uploaded_at:  z.string().optional().or(z.literal("")),
+  manager_notes: z
     .string()
     .trim()
     .max(1000, "Notes are too long")
@@ -53,11 +44,10 @@ export type ClientDocument = z.infer<typeof clientDocumentSchema>;
  * (file_url / file_name are filled programmatically after the Storage upload).
  */
 export const uploadDocumentFormSchema = z.object({
-  document_type:   z.enum(DOCUMENT_TYPE_OPTIONS, {
+  document_type: z.enum(DOCUMENT_TYPE_OPTIONS, {
     errorMap: () => ({ message: "Please select a document type" }),
   }),
-  expiration_date: z.string().optional().or(z.literal("")),
-  manager_notes:   z.string().trim().max(1000).optional().or(z.literal("")),
+  manager_notes: z.string().trim().max(1000).optional().or(z.literal("")),
 });
 
 export type UploadDocumentFormData = z.infer<typeof uploadDocumentFormSchema>;


### PR DESCRIPTION
### Infrastructure & Limits

* Activated Firebase Cloud Storage in `us-east1`.
* Applied free tier caps: 5 GB total storage and 1 GB per day download bandwidth.
* Kept the maximum file upload size at 10 MB.

### Storage Rules

* Updated Firebase Storage rules to require user authentication:

```javascript
rules_version = '2';
service firebase.storage {
  match /b/{bucket}/o {
    match /{allPaths=**} {
      allow read, write: if request.auth != null;
    }
  }
}

```

### Backend & Schema Updates

* Removed `status` and `expiration_date` from schemas (`documentSchema.ts`).
* Removed `status` and `expiration_date` fields from the database upload payload (`DocumentsTabController.ts`).
* Changed dashboard validation to accept legacy document statuses as optional strings (`ManagerDashboardShell.tsx`).

### UI Cleanups

* Deleted the Expiration Date input field from the upload form (`DocumentsTab.tsx`).
* Deleted the Status Legend footer and all status badges from the file rows.
* Wrapped the upload form in a collapsible section using a local state toggle.
* Removed unused `register` and `handleSubmit` variables to fix linter warnings.