### PR TITLE
Add admin-managed custom fields for client profiles

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -155,6 +155,7 @@ service cloud.firestore {
           "logistics",
           "questionnaire",
           "legal_consents",
+          "custom_fields",
           "financial_aid_applications",
           "client_documents"
         ]);
@@ -208,6 +209,19 @@ service cloud.firestore {
       allow update: if (isAdmin() && isOneWayAdminClientUpdate())
         || isClientProfileUpdate(clientId)
         || isClientUidClaim(clientId);
+    }
+
+    match /client_field_definitions/{fieldId} {
+      allow get, list: if signedIn()
+        && (isAdmin() || resource.data.active == true);
+      allow create: if isAdmin()
+        && request.resource.data.id == fieldId
+        && request.resource.data.isCustom == true
+        && request.resource.data.active == true;
+      allow update: if isAdmin()
+        && resource.data.isCustom == true
+        && request.resource.data.isCustom == true;
+      allow delete: if false;
     }
 
     match /programs/{document=**} {

--- a/frontend/src/app/(protected)/clients/page.tsx
+++ b/frontend/src/app/(protected)/clients/page.tsx
@@ -9,6 +9,7 @@ import ClientIntakeForm from "@/components/clients/intake/ClientIntakeForm";
 import ClientProfileDashboard from "@/components/clients/dashboard/ClientProfileDashboard";
 import ClientPageHeader from "@/components/clients/list/ClientPageHeader";
 import ClientFilterBar from "@/components/clients/list/ClientFilterBar";
+import ClientFieldManagerModal from "@/components/clients/fields/ClientFieldManagerModal";
 
 // TIER 2 - APPLICATION LAYER
 import { useClientManagementService } from "@/application/ClientManagementService"; 
@@ -30,6 +31,7 @@ export default function ClientsPage() {
   const [view, setView] = useState<View>("list");
   const [editingClient, setEditingClient] = useState<ClientDoc | null>(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [isFieldManagerOpen, setIsFieldManagerOpen] = useState(false);
 
   // Application Layer - Live Firestore Data Stream
   const { 
@@ -85,6 +87,12 @@ export default function ClientsPage() {
           editingClient={editingClient} 
           onAddNew={handleAddNew} 
           onBackToList={handleBackToList} 
+          onManageFields={() => setIsFieldManagerOpen(true)}
+        />
+
+        <ClientFieldManagerModal
+          isOpen={isFieldManagerOpen}
+          onClose={() => setIsFieldManagerOpen(false)}
         />
 
         {view === "list" && (

--- a/frontend/src/components/clients/fields/ClientFieldManagerModal.tsx
+++ b/frontend/src/components/clients/fields/ClientFieldManagerModal.tsx
@@ -464,6 +464,8 @@ export default function ClientFieldManagerModal({
                           </div>
                         </div>
                       </article>
+
+                      
                     ))}
                   </div>
                 );

--- a/frontend/src/components/clients/fields/ClientFieldManagerModal.tsx
+++ b/frontend/src/components/clients/fields/ClientFieldManagerModal.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  createClientFieldDefinition,
+  getAllClientFieldDefinitionsForAdmin,
+  hideClientFieldDefinition,
+  reactivateClientFieldDefinition,
+  softDeleteClientFieldDefinition,
+  updateClientFieldDefinition,
+} from "@/firebase/clientFieldDefinitionsService";
+import {
+  CUSTOM_FIELD_TYPES,
+  CUSTOM_FIELD_TABS,
+  type ClientFieldDefinition,
+  type CustomFieldTab,
+  type CustomFieldType,
+} from "@/schema/customFieldSchema";
+
+const TAB_LABELS: Record<CustomFieldTab, string> = {
+  profile: "Profile & Demographics",
+  medical: "Medical",
+  contacts: "Contacts",
+  logistics: "Logistics",
+  questionnaire: "Questionnaire",
+  legal_consents: "Legal Consents",
+  documents: "Documents",
+  financial_aid: "Financial Aid",
+};
+
+interface ClientFieldManagerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function humanizeType(type: string) {
+  return type.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export default function ClientFieldManagerModal({
+  isOpen,
+  onClose,
+}: ClientFieldManagerModalProps) {
+  const [definitions, setDefinitions] = useState<ClientFieldDefinition[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [reactivatingId, setReactivatingId] = useState<string | null>(null);
+  const [hidingId, setHidingId] = useState<string | null>(null);
+  const [editingField, setEditingField] = useState<ClientFieldDefinition | null>(null);
+  const [label, setLabel] = useState("");
+  const [type, setType] = useState<CustomFieldType>("text");
+  const [tab, setTab] = useState<CustomFieldTab>("profile");
+  const [optionsText, setOptionsText] = useState("");
+
+  const visibleDefinitions = useMemo(
+    () => definitions.filter((definition) => definition.hiddenFromManager !== true),
+    [definitions],
+  );
+
+  const groupedDefinitions = useMemo(
+    () =>
+      CUSTOM_FIELD_TABS.map((tabId) => ({
+        tab: tabId,
+        label: TAB_LABELS[tabId],
+        active: visibleDefinitions.filter(
+          (definition) => definition.active && definition.tab === tabId,
+        ),
+        inactive: visibleDefinitions.filter(
+          (definition) => !definition.active && definition.tab === tabId,
+        ),
+      })),
+    [visibleDefinitions],
+  );
+
+  function resetFieldForm() {
+    setEditingField(null);
+    setLabel("");
+    setType("text");
+    setTab("profile");
+    setOptionsText("");
+  }
+
+  function startEditing(field: ClientFieldDefinition) {
+    setEditingField(field);
+    setLabel(field.label);
+    setType(field.type);
+    setTab(field.tab);
+    setOptionsText(field.options.join("\n"));
+  }
+
+  async function loadDefinitions() {
+    setIsLoading(true);
+    try {
+      const data = await getAllClientFieldDefinitionsForAdmin();
+      setDefinitions(data);
+    } catch (error) {
+      console.error("[ClientFieldManagerModal] load failed:", error);
+      toast.error("Failed to load client fields.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      const timeoutId = window.setTimeout(() => {
+        void loadDefinitions();
+      }, 0);
+
+      return () => window.clearTimeout(timeoutId);
+    }
+  }, [isOpen]);
+
+  async function handleSubmitField(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedLabel = label.trim();
+
+    if (!trimmedLabel) {
+      toast.error("Field label is required.");
+      return;
+    }
+
+    const options = optionsText
+      .split("\n")
+      .map((option) => option.trim())
+      .filter(Boolean);
+
+    if ((!editingField && type === "select" && options.length === 0) || (editingField?.type === "select" && options.length === 0)) {
+      toast.error("Select fields need at least one option.");
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      if (editingField) {
+        await updateClientFieldDefinition(editingField.id, {
+          label: trimmedLabel,
+          tab,
+          options: editingField.type === "select" ? options : [],
+        });
+        toast.success("Custom field updated.");
+      } else {
+        await createClientFieldDefinition({
+          label: trimmedLabel,
+          type,
+          tab,
+          options,
+        });
+        toast.success("Custom field added.");
+      }
+      resetFieldForm();
+      await loadDefinitions();
+    } catch (error) {
+      console.error("[ClientFieldManagerModal] save failed:", error);
+      toast.error(editingField ? "Failed to update custom field." : "Failed to add custom field.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDeactivate(field: ClientFieldDefinition) {
+    if (!field.isCustom || !field.active) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Deactivate "${field.label}"? Existing client values will stay saved in Firestore.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setDeletingId(field.id);
+    try {
+      await softDeleteClientFieldDefinition(field.id);
+      await loadDefinitions();
+      toast.success("Custom field deactivated.");
+    } catch (error) {
+      console.error("[ClientFieldManagerModal] deactivate failed:", error);
+      toast.error("Failed to deactivate custom field.");
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  async function handleReactivate(field: ClientFieldDefinition) {
+    if (!field.isCustom || field.active) {
+      return;
+    }
+
+    setReactivatingId(field.id);
+    try {
+      await reactivateClientFieldDefinition(field.id);
+      await loadDefinitions();
+      toast.success("Custom field reactivated.");
+    } catch (error) {
+      console.error("[ClientFieldManagerModal] reactivate failed:", error);
+      toast.error("Failed to reactivate custom field.");
+    } finally {
+      setReactivatingId(null);
+    }
+  }
+
+  async function handleHide(field: ClientFieldDefinition) {
+    if (!field.isCustom || field.active) {
+      return;
+    }
+
+    const confirmed = window.confirm(
+      `Hide "${field.label}" from this list? The field definition and client values will stay in Firestore.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    setHidingId(field.id);
+    try {
+      await hideClientFieldDefinition(field.id);
+      await loadDefinitions();
+      toast.success("Custom field hidden from the manager list.");
+    } catch (error) {
+      console.error("[ClientFieldManagerModal] hide failed:", error);
+      toast.error("Failed to hide custom field.");
+    } finally {
+      setHidingId(null);
+    }
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#15383E]/65 p-4 backdrop-blur-sm">
+      <section className="max-h-[90vh] w-full max-w-4xl overflow-y-auto rounded-[1.75rem] border border-white/70 bg-[#FFFDF8] shadow-[0_24px_60px_rgba(21,56,62,0.28)]">
+        <header className="flex flex-col gap-3 border-b border-[#D7E3D5] px-5 py-5 sm:flex-row sm:items-start sm:justify-between sm:px-6">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-[0.16em] text-[#6A8589]">
+              Client fields
+            </p>
+            <h2 className="mt-1 text-2xl font-bold tracking-[-0.03em] text-[#15383E]">
+              Manage custom fields
+            </h2>
+            <p className="mt-1 max-w-2xl text-sm leading-5 text-[#607B80]">
+              Add, edit, deactivate, reactivate, or hide custom fields without deleting stored client values.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="self-start rounded-full border border-[#B9CFCA] bg-white px-4 py-2 text-sm font-bold text-[#31585F] transition hover:bg-[#EEF4EC] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6BB2A0]"
+          >
+            Close
+          </button>
+        </header>
+
+        <div className="grid gap-5 p-5 sm:p-6 lg:grid-cols-[1fr_1.1fr]">
+          <div className="space-y-5">
+            <form
+              onSubmit={handleSubmitField}
+              className="rounded-2xl border border-[#D7E3D5] bg-white p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-bold text-[#15383E]">
+                    {editingField ? "Edit custom field" : "Add custom field"}
+                  </h3>
+                  {editingField && (
+                    <p className="mt-1 text-xs font-medium text-[#6A8589]">
+                      Field type is locked to protect existing values.
+                    </p>
+                  )}
+                </div>
+                {editingField && (
+                  <button
+                    type="button"
+                    onClick={resetFieldForm}
+                    className="rounded-full border border-[#B9CFCA] px-3 py-1.5 text-xs font-bold text-[#31585F] transition hover:bg-[#EEF4EC]"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
+              <div className="mt-4 space-y-4">
+                <label className="block">
+                  <span className="text-sm font-semibold text-[#31585F]">Label</span>
+                  <input
+                    type="text"
+                    value={label}
+                    onChange={(event) => setLabel(event.target.value)}
+                    maxLength={80}
+                    className="mt-1 w-full rounded-xl border border-[#BFD0CA] bg-white px-3.5 py-2.5 text-sm text-[#15383E] outline-none transition focus:border-[#6BB2A0] focus:ring-4 focus:ring-[#D7E7D4]"
+                    placeholder="e.g. Preferred contact time"
+                  />
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-[#31585F]">Type</span>
+                  <select
+                    value={type}
+                    onChange={(event) => setType(event.target.value as CustomFieldType)}
+                    disabled={Boolean(editingField)}
+                    className="mt-1 w-full rounded-xl border border-[#BFD0CA] bg-white px-3.5 py-2.5 text-sm text-[#15383E] outline-none transition focus:border-[#6BB2A0] focus:ring-4 focus:ring-[#D7E7D4]"
+                  >
+                    {CUSTOM_FIELD_TYPES.map((fieldType) => (
+                      <option key={fieldType} value={fieldType}>
+                        {humanizeType(fieldType)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block">
+                  <span className="text-sm font-semibold text-[#31585F]">Target tab</span>
+                  <select
+                    value={tab}
+                    onChange={(event) => setTab(event.target.value as CustomFieldTab)}
+                    className="mt-1 w-full rounded-xl border border-[#BFD0CA] bg-white px-3.5 py-2.5 text-sm text-[#15383E] outline-none transition focus:border-[#6BB2A0] focus:ring-4 focus:ring-[#D7E7D4]"
+                  >
+                    {CUSTOM_FIELD_TABS.map((tabId) => (
+                      <option key={tabId} value={tabId}>
+                        {TAB_LABELS[tabId]}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                {(editingField?.type === "select" || (!editingField && type === "select")) && (
+                  <label className="block">
+                    <span className="text-sm font-semibold text-[#31585F]">
+                      Options
+                    </span>
+                    <textarea
+                      value={optionsText}
+                      onChange={(event) => setOptionsText(event.target.value)}
+                      rows={4}
+                      className="mt-1 w-full resize-y rounded-xl border border-[#BFD0CA] bg-white px-3.5 py-2.5 text-sm text-[#15383E] outline-none transition focus:border-[#6BB2A0] focus:ring-4 focus:ring-[#D7E7D4]"
+                      placeholder={"One option per line\nMorning\nAfternoon\nEvening"}
+                    />
+                  </label>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={isSaving}
+                  className="inline-flex w-full items-center justify-center rounded-full bg-[#245C66] px-4 py-2.5 text-sm font-bold text-white transition hover:bg-[#173A40] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6BB2A0] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSaving
+                    ? editingField
+                      ? "Saving..."
+                      : "Adding..."
+                    : editingField
+                      ? "Save changes"
+                      : "Add custom field"}
+                </button>
+              </div>
+            </form>
+          </div>
+
+          <section className="rounded-2xl border border-[#D7E3D5] bg-white p-4">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-bold text-[#15383E]">Custom fields</h3>
+              {isLoading && (
+                <span className="text-xs font-semibold text-[#6A8589]">Loading...</span>
+              )}
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {visibleDefinitions.length === 0 && !isLoading && (
+                <p className="rounded-xl border border-dashed border-[#B9CFCA] bg-[#EEF4EC] px-4 py-6 text-center text-sm font-medium text-[#607B80]">
+                  No custom fields yet.
+                </p>
+              )}
+
+              {groupedDefinitions.map((group) => {
+                if (group.active.length === 0 && group.inactive.length === 0) {
+                  return null;
+                }
+
+                return (
+                  <div key={group.tab} className="space-y-3 border-t border-[#D7E3D5] pt-4 first:border-t-0 first:pt-0">
+                    <h4 className="text-xs font-bold uppercase tracking-[0.16em] text-[#6A8589]">
+                      {group.label}
+                    </h4>
+
+                    {group.active.map((field) => (
+                      <article
+                        key={field.id}
+                        className="rounded-xl border border-[#D7E3D5] bg-[#F7FAF5] p-4"
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                          <div>
+                            <p className="font-bold text-[#15383E]">{field.label}</p>
+                            <p className="mt-1 text-xs font-semibold uppercase tracking-[0.12em] text-[#6A8589]">
+                              {humanizeType(field.type)}
+                            </p>
+                            {field.type === "select" && field.options.length > 0 && (
+                              <p className="mt-2 text-xs leading-5 text-[#607B80]">
+                                {field.options.join(", ")}
+                              </p>
+                            )}
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() => startEditing(field)}
+                              className="rounded-full border border-[#B9CFCA] bg-white px-3 py-1.5 text-xs font-bold text-[#31585F] transition hover:bg-[#EEF4EC]"
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleDeactivate(field)}
+                              disabled={deletingId === field.id}
+                              className="rounded-full border border-red-200 bg-white px-3 py-1.5 text-xs font-bold text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {deletingId === field.id ? "Deactivating..." : "Deactivate"}
+                            </button>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
+
+                    {group.inactive.map((field) => (
+                      <article
+                        key={field.id}
+                        className="rounded-xl border border-[#E4ECE2] bg-[#F8F7F0] px-4 py-3 opacity-90"
+                      >
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="text-sm font-bold text-[#607B80]">{field.label}</p>
+                            <p className="mt-0.5 text-xs text-[#8BA0A3]">
+                              {humanizeType(field.type)} · Inactive
+                            </p>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <button
+                              type="button"
+                              onClick={() => startEditing(field)}
+                              className="rounded-full border border-[#B9CFCA] bg-white px-3 py-1.5 text-xs font-bold text-[#31585F] transition hover:bg-[#EEF4EC]"
+                            >
+                              Edit
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleReactivate(field)}
+                              disabled={reactivatingId === field.id}
+                              className="rounded-full border border-[#B9CFCA] bg-white px-3 py-1.5 text-xs font-bold text-[#31585F] transition hover:bg-[#EEF4EC] disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {reactivatingId === field.id ? "Reactivating..." : "Reactivate"}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleHide(field)}
+                              disabled={hidingId === field.id}
+                              className="rounded-full border border-[#D7E3D5] bg-white px-3 py-1.5 text-xs font-bold text-[#6A8589] transition hover:bg-[#EEF4EC] disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                              {hidingId === field.id ? "Hiding..." : "Remove"}
+                            </button>
+                          </div>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/clients/fields/CustomFieldsSection.tsx
+++ b/frontend/src/components/clients/fields/CustomFieldsSection.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import type { FieldValues, Path, RegisterOptions, UseFormReturn } from "react-hook-form";
+import { toast } from "sonner";
+import { getActiveClientFieldDefinitions } from "@/firebase/clientFieldDefinitionsService";
+import { updateClientDoc } from "@/firebase/clientDbService";
+import type { ClientDoc } from "@/components/clients/list/ClientList";
+import type {
+  ClientFieldDefinition,
+  CustomFields,
+  CustomFieldValue,
+  CustomFieldTab,
+} from "@/schema/customFieldSchema";
+
+interface CustomFieldsSectionProps<TFormValues extends FieldValues> {
+  tab: CustomFieldTab;
+  form?: UseFormReturn<TFormValues>;
+  client?: ClientDoc;
+  isEditable?: boolean;
+}
+
+type CustomFieldsFormData = {
+  custom_fields: CustomFields;
+};
+
+type StandaloneCustomFieldPath = `custom_fields.${string}`;
+
+type CustomFieldRegisterOptions = {
+  setValueAs?: (value: unknown) => CustomFieldValue;
+};
+
+const VIEW_CLS = "w-full border-0 bg-transparent px-0 py-1 text-sm text-slate-800 outline-none";
+
+function inputCls() {
+  return [
+    "w-full rounded-lg border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none",
+    "placeholder:text-slate-400 transition-colors duration-150 hover:border-slate-400",
+    "focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1",
+  ].join(" ");
+}
+
+function textareaCls() {
+  return [
+    "w-full min-h-[88px] resize-y rounded-lg border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none",
+    "placeholder:text-slate-400 transition-colors duration-150 hover:border-slate-400",
+    "focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1",
+  ].join(" ");
+}
+
+function selectCls() {
+  return [
+    "w-full appearance-none rounded-lg border border-slate-300 bg-white px-3.5 py-2.5 text-sm text-slate-800 outline-none",
+    "transition-colors duration-150 hover:border-slate-400 focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1",
+  ].join(" ");
+}
+
+export default function CustomFieldsSection<TFormValues extends FieldValues>({
+  tab,
+  form,
+  client,
+  isEditable = true,
+}: CustomFieldsSectionProps<TFormValues>) {
+  const [definitions, setDefinitions] = useState<ClientFieldDefinition[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const standaloneForm = useForm<CustomFieldsFormData>({
+    defaultValues: {
+      custom_fields: client?.custom_fields ?? {},
+    },
+  });
+  const shouldUseStandaloneSave = !form && Boolean(client);
+  const registerCustomField = (
+    fieldPath: Path<TFormValues>,
+    standaloneFieldPath: `custom_fields.${string}`,
+    options?: CustomFieldRegisterOptions,
+  ) =>
+    form
+      ? form.register(fieldPath, options as Parameters<typeof form.register>[1])
+      : standaloneForm.register(
+          standaloneFieldPath,
+          options as RegisterOptions<CustomFieldsFormData, StandaloneCustomFieldPath>,
+        );
+
+  useEffect(() => {
+    let shouldIgnore = false;
+
+    async function loadDefinitions() {
+      setIsLoading(true);
+      try {
+        const data = await getActiveClientFieldDefinitions();
+        if (!shouldIgnore) {
+          setDefinitions(data.filter((definition) => definition.tab === tab));
+        }
+      } catch (error) {
+        console.error("[CustomFieldsSection] load failed:", error);
+        if (!shouldIgnore) {
+          setDefinitions([]);
+        }
+      } finally {
+        if (!shouldIgnore) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void loadDefinitions();
+
+    return () => {
+      shouldIgnore = true;
+    };
+  }, [tab]);
+
+  if (isLoading) {
+    return (
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="text-sm font-semibold text-slate-500">Loading custom fields...</p>
+      </section>
+    );
+  }
+
+  if (definitions.length === 0) {
+    return null;
+  }
+
+  async function handleStandaloneSubmit(data: CustomFieldsFormData) {
+    if (!client) {
+      return;
+    }
+
+    setIsSaving(true);
+    const mergedData = {
+      custom_fields: {
+        ...(client.custom_fields ?? {}),
+        ...(data.custom_fields ?? {}),
+      },
+    };
+
+    try {
+      await updateClientDoc(client.id, mergedData);
+      standaloneForm.reset(mergedData);
+      toast.success("Custom fields saved successfully.");
+    } catch (error) {
+      console.error("[CustomFieldsSection] save failed:", error);
+      toast.error("Failed to save custom fields.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const content = (
+    <>
+      <div className="mb-5">
+        <h3 className="text-base font-bold text-slate-800">Additional information</h3>
+        <p className="mt-1 text-sm text-slate-500">
+          Custom fields configured by administrators.
+        </p>
+      </div>
+
+      <div className="grid gap-5 sm:grid-cols-2">
+        {definitions.map((field) => {
+          const fieldPath = `custom_fields.${field.id}` as Path<TFormValues>;
+          const standaloneFieldPath = `custom_fields.${field.id}` as const;
+
+          if (field.type === "textarea") {
+            return (
+              <label key={field.id} className="flex flex-col gap-1 sm:col-span-2">
+                <span className="text-sm font-semibold text-slate-700">{field.label}</span>
+                <textarea
+                  readOnly={!isEditable}
+                  className={isEditable ? textareaCls() : VIEW_CLS}
+                  {...registerCustomField(fieldPath, standaloneFieldPath)}
+                />
+              </label>
+            );
+          }
+
+          if (field.type === "select") {
+            return (
+              <label key={field.id} className="flex flex-col gap-1">
+                <span className="text-sm font-semibold text-slate-700">{field.label}</span>
+                <select
+                  disabled={!isEditable}
+                  className={isEditable ? selectCls() : VIEW_CLS}
+                  {...registerCustomField(fieldPath, standaloneFieldPath)}
+                >
+                  <option value="">Select option...</option>
+                  {field.options.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            );
+          }
+
+          if (field.type === "checkbox") {
+            return (
+              <label
+                key={field.id}
+                className={[
+                  "flex items-center gap-3 rounded-lg border px-4 py-3",
+                  isEditable ? "border-slate-200 bg-slate-50" : "border-transparent bg-transparent px-0",
+                ].join(" ")}
+              >
+                <input
+                  type="checkbox"
+                  disabled={!isEditable}
+                  className="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                  {...registerCustomField(fieldPath, standaloneFieldPath)}
+                />
+                <span className="text-sm font-semibold text-slate-700">{field.label}</span>
+              </label>
+            );
+          }
+
+          return (
+            <label key={field.id} className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-slate-700">{field.label}</span>
+              <input
+                type={field.type === "date" ? "date" : field.type === "number" ? "number" : "text"}
+                readOnly={!isEditable}
+                className={isEditable ? inputCls() : VIEW_CLS}
+                {...registerCustomField(fieldPath, standaloneFieldPath, {
+                  setValueAs:
+                    field.type === "number"
+                      ? (value: unknown) => {
+                          if (value === "" || value === undefined) {
+                            return null;
+                          }
+
+                          const parsed = Number(value);
+                          return Number.isNaN(parsed) ? null : parsed;
+                        }
+                      : undefined,
+                })}
+              />
+            </label>
+          );
+        })}
+      </div>
+
+      {shouldUseStandaloneSave && isEditable && (
+        <div className="mt-5 flex items-center justify-between gap-3 border-t border-slate-100 pt-4">
+          <p className="text-xs text-slate-400">
+            Values are saved under the client&apos;s custom fields.
+          </p>
+          <button
+            type="button"
+            onClick={standaloneForm.handleSubmit(handleStandaloneSubmit)}
+            disabled={isSaving || !standaloneForm.formState.isDirty}
+            className={[
+              "rounded-lg px-5 py-2 text-sm font-semibold text-white shadow-sm transition-colors",
+              isSaving || !standaloneForm.formState.isDirty
+                ? "cursor-not-allowed bg-indigo-300"
+                : "bg-indigo-600 hover:bg-indigo-700",
+            ].join(" ")}
+          >
+            {isSaving ? "Saving..." : "Save custom fields"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+
+  if (shouldUseStandaloneSave) {
+    return (
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+        {content}
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
+      {content}
+    </section>
+  );
+}

--- a/frontend/src/components/clients/intake/ClientIntakeForm.tsx
+++ b/frontend/src/components/clients/intake/ClientIntakeForm.tsx
@@ -11,6 +11,7 @@ import { useClientManagementService } from "@/application/ClientManagementServic
 // TIER 1 — Presentation sub-components
 import BasicInfoStep from "./BasicInfoStep";
 import ContactsStep from "./ContactsStep";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // ─── Default values ───────────────────────────────────────────────────────────
 
@@ -38,6 +39,7 @@ const DEFAULT_VALUES: ClientFormInput = {
     medical_clearance_status: undefined,
   },
   contacts: [],
+  custom_fields: {},
 };
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -121,6 +123,10 @@ export default function ClientIntakeForm({ onSaveSuccess, onCancel }: ClientInta
           {/* ── Contacts Section ── */}
           <div className="mt-4">
             <ContactsStep />
+          </div>
+
+          <div className="mt-4">
+            <CustomFieldsSection tab="profile" form={methods} />
           </div>
 
           {/* ── Footer: Cancel + Save ── */}

--- a/frontend/src/components/clients/list/ClientPageHeader.tsx
+++ b/frontend/src/components/clients/list/ClientPageHeader.tsx
@@ -8,6 +8,7 @@ interface ClientPageHeaderProps {
   editingClient: ClientDoc | null;
   onAddNew: () => void;
   onBackToList: () => void;
+  onManageFields?: () => void;
 }
 
 export default function ClientPageHeader({
@@ -15,6 +16,7 @@ export default function ClientPageHeader({
   editingClient,
   onAddNew,
   onBackToList,
+  onManageFields,
 }: ClientPageHeaderProps) {
   if (view === "dashboard") return null;
 
@@ -42,14 +44,25 @@ export default function ClientPageHeader({
 
         <div className="flex flex-wrap items-center gap-2 sm:justify-end">
         {view === "list" ? (
-          <button
-            type="button"
-            onClick={onAddNew}
-            className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-white/90 px-3.5 py-2 text-sm font-bold text-[#15383E] shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#B9D4CC] focus-visible:ring-offset-2 focus-visible:ring-offset-[#245C66]"
-          >
-            <IconPlus className="h-4 w-4" />
-            Add new client
-          </button>
+          <>
+            {onManageFields && (
+              <button
+                type="button"
+                onClick={onManageFields}
+                className="inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-white/30 bg-white/10 px-3.5 py-2 text-sm font-bold text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+              >
+                Manage fields
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onAddNew}
+              className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-white/90 px-3.5 py-2 text-sm font-bold text-[#15383E] shadow-sm transition hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#B9D4CC] focus-visible:ring-offset-2 focus-visible:ring-offset-[#245C66]"
+            >
+              <IconPlus className="h-4 w-4" />
+              Add new client
+            </button>
+          </>
         ) : (
           <button
             type="button"

--- a/frontend/src/components/clients/tabs/ContactsTab.tsx
+++ b/frontend/src/components/clients/tabs/ContactsTab.tsx
@@ -4,6 +4,7 @@ import type { FieldErrors } from "react-hook-form";
 import { CONTACT_RELATIONSHIP } from "@/schema/constants";
 import type { Contact } from "@/schema/contactSchema";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useContactsTabController, EMPTY_CONTACT } from "./controllers/ContactsTabController";
@@ -187,6 +188,10 @@ export default function ContactsTab({ client, isEditable }: ContactsTabProps) {
         </div>
 
         {/* ── Sticky footer ── */}
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="contacts" client={client} isEditable={isEditable} />
+        </div>
+
         {isEditable && (
           <div className="flex items-center justify-between rounded-b-xl border-t border-slate-100 bg-slate-50 px-6 py-4 sm:px-8">
             {isDirty ? (

--- a/frontend/src/components/clients/tabs/DocumentsTab.tsx
+++ b/frontend/src/components/clients/tabs/DocumentsTab.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 
 import { DOCUMENT_TYPE_OPTIONS, type ClientDocument } from "@/schema/documentSchema";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useDocumentsTabController } from "./controllers/DocumentsTabController";
@@ -14,6 +15,15 @@ interface DocumentsTabProps {
   client: ClientDoc;
 }
 
+const DOCUMENT_STATUS_OPTIONS = ["active", "expired", "pending_review", "rejected"] as const;
+type DocumentStatus = (typeof DOCUMENT_STATUS_OPTIONS)[number];
+
+const STATUS_BADGE: Record<DocumentStatus, { bg: string; text: string; border: string }> = {
+  active: { bg: "bg-emerald-50", text: "text-emerald-700", border: "border-emerald-200" },
+  expired: { bg: "bg-red-50", text: "text-red-700", border: "border-red-200" },
+  pending_review: { bg: "bg-amber-50", text: "text-amber-700", border: "border-amber-200" },
+  rejected: { bg: "bg-slate-100", text: "text-slate-600", border: "border-slate-200" },
+};
 
 // ─── Helpers (Pure UI) ────────────────────────────────────────────────────────
 
@@ -138,6 +148,21 @@ export default function DocumentsTab({ client }: DocumentsTabProps) {
         uploadState={uploadState}
         actions={actions}
       />
+
+      <CustomFieldsSection tab="documents" client={client} isEditable />
+
+      {/* ════ Section 3: Status legend ════ */}
+      <div className="flex flex-wrap gap-3 px-1">
+        <p className="w-full text-xs font-semibold text-slate-400 uppercase tracking-wide">Status legend</p>
+        {DOCUMENT_STATUS_OPTIONS.map((s) => {
+          const b = STATUS_BADGE[s];
+          return (
+            <span key={s} className={["rounded-full border px-2.5 py-0.5 text-xs font-semibold", b.bg, b.text, b.border].join(" ")}>
+              {humanize(s)}
+            </span>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/clients/tabs/FinancialAidTab.tsx
+++ b/frontend/src/components/clients/tabs/FinancialAidTab.tsx
@@ -3,6 +3,7 @@
 import { useFieldArray, Control, UseFormRegister, FieldErrors } from "react-hook-form";
 import { FINANCIAL_AID_STATUS, type FinancialAidTabFormData, type FinancialAidApplication, type PaymentInstallment } from "@/schema/financialAidSchema";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useFinancialAidTabController, EMPTY_APPLICATION, EMPTY_INSTALLMENT } from "./controllers/FinancialAidTabController";
@@ -314,6 +315,10 @@ export default function FinancialAidTab({ client, isEditable }: FinancialAidTabP
         </div>
 
         {/* ── Sticky footer ── */}
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="financial_aid" client={client} isEditable={isEditable} />
+        </div>
+
         {isEditable && (
           <div className="flex items-center justify-between rounded-b-xl border-t border-slate-100 bg-slate-50 px-6 py-4 sm:px-8">
             {isDirty ? (

--- a/frontend/src/components/clients/tabs/LegalConsentsTab.tsx
+++ b/frontend/src/components/clients/tabs/LegalConsentsTab.tsx
@@ -2,6 +2,7 @@
 
 import { AccordionSection } from "@/components/ui/AccordionSection";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useLegalConsentsTabController } from "./controllers/LegalConsentsTabController";
@@ -238,6 +239,10 @@ export default function LegalConsentsTab({ client, isEditable }: LegalConsentsTa
         </div>
 
         {/* ── Sticky footer (edit mode only) ── */}
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="legal_consents" client={client} isEditable={isEditable} />
+        </div>
+
         {isEditable && (
           <div className="flex items-center justify-between rounded-b-xl border-t border-slate-100 bg-slate-50 px-6 py-4 sm:px-8">
             {isDirty ? (

--- a/frontend/src/components/clients/tabs/LogisticsTab.tsx
+++ b/frontend/src/components/clients/tabs/LogisticsTab.tsx
@@ -2,6 +2,7 @@
 
 import { AccordionSection } from "@/components/ui/AccordionSection";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useLogisticsTabController } from "./controllers/LogisticsTabController";
@@ -169,6 +170,10 @@ export default function LogisticsTab({ client, isEditable }: LogisticsTabProps) 
         </div>
 
         {/* ── Sticky footer (edit mode only) ── */}
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="logistics" client={client} isEditable={isEditable} />
+        </div>
+
         {isEditable && (
           <div className="flex items-center justify-between rounded-b-xl border-t border-slate-100 bg-slate-50 px-6 py-4 sm:px-8">
             {isDirty ? (

--- a/frontend/src/components/clients/tabs/MedicalTab.tsx
+++ b/frontend/src/components/clients/tabs/MedicalTab.tsx
@@ -5,6 +5,7 @@ import type { FieldErrors } from "react-hook-form";
 import { MEDICAL_CLEARANCE_STATUS } from "@/schema/constants";
 import type { HealthcareProvider, Vaccination, Hospitalization } from "@/schema/medicalSchema";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { 
@@ -627,6 +628,10 @@ export default function MedicalTab({ client, isEditable }: MedicalTabProps) {
             </div>
           </AccordionSection>
 
+        </div>
+
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="medical" client={client} isEditable={isEditable} />
         </div>
 
         {/* ── Sticky footer ── */}

--- a/frontend/src/components/clients/tabs/ProfileTab.tsx
+++ b/frontend/src/components/clients/tabs/ProfileTab.tsx
@@ -5,6 +5,7 @@ import type { Dependent } from "@/schema/supplementarySchema";
 import { AccordionSection } from "@/components/ui/AccordionSection";
 import { GENDER_OPTIONS, EDUCATION_STATUS_OPTIONS } from "@/schema/constants";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our new Tier 2 Controller
 import { useProfileTabController, EMPTY_DEPENDENT } from "./controllers/ProfileTabController";
@@ -354,6 +355,8 @@ export default function ProfileTab({ client, isEditable }: ProfileTabProps) {
               })}
             </div>
           </AccordionSection>
+
+          <CustomFieldsSection tab="profile" form={form} isEditable={isEditable} />
         </div>
 
         {/* ── Sticky footer ── */}

--- a/frontend/src/components/clients/tabs/QuestionnaireTab.tsx
+++ b/frontend/src/components/clients/tabs/QuestionnaireTab.tsx
@@ -2,6 +2,7 @@
 
 import { AccordionSection } from "@/components/ui/AccordionSection";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
+import CustomFieldsSection from "@/components/clients/fields/CustomFieldsSection";
 
 // Import our Tier 2 Controller
 import { useQuestionnaireTabController } from "./controllers/QuestionnaireTabController";
@@ -189,6 +190,10 @@ export default function QuestionnaireTab({ client, isEditable }: QuestionnaireTa
         </div>
 
         {/* ── Sticky footer (edit mode only) ── */}
+        <div className="px-6 pb-6 sm:px-8 sm:pb-8">
+          <CustomFieldsSection tab="questionnaire" client={client} isEditable={isEditable} />
+        </div>
+
         {isEditable && (
           <div className="flex items-center justify-between rounded-b-xl border-t border-slate-100 bg-slate-50 px-6 py-4 sm:px-8">
             {isDirty ? (

--- a/frontend/src/components/clients/tabs/controllers/ProfileTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/ProfileTabController.ts
@@ -58,6 +58,7 @@ export function useProfileTabController(client: ClientDoc) {
         relationship: d.relationship ?? "",
         dob: d.dob ?? "",
       })),
+      custom_fields: client.custom_fields ?? {},
     },
   });
 
@@ -104,8 +105,15 @@ export function useProfileTabController(client: ClientDoc) {
   async function onSubmit(data: BasicInfoFormData) {
     setIsSaving(true);
     try {
-      await updateClientDoc(client.id, data);
-      form.reset(data); // Resets isDirty state so the save button disables again
+      const mergedData = {
+        ...data,
+        custom_fields: {
+          ...(client.custom_fields ?? {}),
+          ...(data.custom_fields ?? {}),
+        },
+      };
+      await updateClientDoc(client.id, mergedData);
+      form.reset(mergedData); // Resets isDirty state so the save button disables again
       toast.success("Profile saved successfully.");
     } catch (err) {
       console.error("[ProfileTabController] Update failed:", err);

--- a/frontend/src/firebase/clientDbService.ts
+++ b/frontend/src/firebase/clientDbService.ts
@@ -83,6 +83,7 @@ function pickClientEditableFields(payload: Record<string, any>): Record<string, 
     "logistics",
     "questionnaire",
     "legal_consents",
+    "custom_fields",
     "financial_aid_applications",
     "client_documents",
   ]);

--- a/frontend/src/firebase/clientFieldDefinitionsService.ts
+++ b/frontend/src/firebase/clientFieldDefinitionsService.ts
@@ -1,0 +1,165 @@
+import {
+  collection,
+  doc,
+  getDocs,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore";
+import { auth } from "@/firebase/firebase";
+import { getFirestoreDb } from "@/firebase/clientDbService";
+import type {
+  ClientFieldDefinition,
+  CustomFieldTab,
+  CustomFieldType,
+} from "@/schema/customFieldSchema";
+
+const COLLECTION_NAME = "client_field_definitions";
+
+export interface CreateClientFieldDefinitionInput {
+  label: string;
+  type: CustomFieldType;
+  tab: CustomFieldTab;
+  options?: string[];
+}
+
+export interface UpdateClientFieldDefinitionInput {
+  label: string;
+  tab: CustomFieldTab;
+  options?: string[];
+}
+
+function normalizeOptions(type: CustomFieldType, options?: string[]) {
+  if (type !== "select") {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      (options ?? [])
+        .map((option) => option.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function mapDefinition(id: string, data: Record<string, unknown>): ClientFieldDefinition {
+  return {
+    id,
+    label: typeof data.label === "string" ? data.label : "",
+    type: data.type as CustomFieldType,
+    tab: typeof data.tab === "string" ? (data.tab as CustomFieldTab) : "profile",
+    options: Array.isArray(data.options)
+      ? data.options.filter((option): option is string => typeof option === "string")
+      : [],
+    isCustom: true,
+    active: data.active === true,
+    hiddenFromManager: data.hiddenFromManager === true,
+    createdBy: typeof data.createdBy === "string" ? data.createdBy : "",
+    createdAt: data.createdAt,
+    updatedAt: data.updatedAt,
+    deletedAt: data.deletedAt ?? null,
+    deletedBy: typeof data.deletedBy === "string" ? data.deletedBy : null,
+    order: typeof data.order === "number" ? data.order : 0,
+  };
+}
+
+export async function getActiveClientFieldDefinitions(): Promise<ClientFieldDefinition[]> {
+  const snapshot = await getDocs(
+    query(
+      collection(getFirestoreDb(), COLLECTION_NAME),
+      where("active", "==", true),
+    ),
+  );
+
+  return snapshot.docs
+    .map((fieldDoc) => mapDefinition(fieldDoc.id, fieldDoc.data()))
+    .sort((a, b) => a.order - b.order);
+}
+
+export async function getAllClientFieldDefinitionsForAdmin(): Promise<ClientFieldDefinition[]> {
+  const snapshot = await getDocs(
+    query(collection(getFirestoreDb(), COLLECTION_NAME), orderBy("order", "asc")),
+  );
+
+  return snapshot.docs.map((fieldDoc) => mapDefinition(fieldDoc.id, fieldDoc.data()));
+}
+
+export async function createClientFieldDefinition(
+  data: CreateClientFieldDefinitionInput,
+): Promise<void> {
+  const user = auth?.currentUser;
+
+  if (!user) {
+    throw new Error("You must be signed in to create client fields.");
+  }
+
+  const definitionRef = doc(collection(getFirestoreDb(), COLLECTION_NAME));
+  const label = data.label.trim();
+
+  await setDoc(definitionRef, {
+    id: definitionRef.id,
+    label,
+    type: data.type,
+    tab: data.tab,
+    options: normalizeOptions(data.type, data.options),
+    isCustom: true,
+    active: true,
+    hiddenFromManager: false,
+    createdBy: user.uid,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    deletedAt: null,
+    deletedBy: null,
+    order: Date.now(),
+  });
+}
+
+export async function updateClientFieldDefinition(
+  fieldId: string,
+  data: UpdateClientFieldDefinitionInput,
+): Promise<void> {
+  const label = data.label.trim();
+
+  await updateDoc(doc(getFirestoreDb(), COLLECTION_NAME, fieldId), {
+    label,
+    tab: data.tab,
+    options: normalizeOptions("select", data.options),
+    updatedAt: serverTimestamp(),
+  });
+}
+
+export async function softDeleteClientFieldDefinition(fieldId: string): Promise<void> {
+  const user = auth?.currentUser;
+
+  if (!user) {
+    throw new Error("You must be signed in to deactivate client fields.");
+  }
+
+  await updateDoc(doc(getFirestoreDb(), COLLECTION_NAME, fieldId), {
+    active: false,
+    updatedAt: serverTimestamp(),
+    deletedAt: serverTimestamp(),
+    deletedBy: user.uid,
+  });
+}
+
+export async function reactivateClientFieldDefinition(fieldId: string): Promise<void> {
+  await updateDoc(doc(getFirestoreDb(), COLLECTION_NAME, fieldId), {
+    active: true,
+    hiddenFromManager: false,
+    updatedAt: serverTimestamp(),
+    deletedAt: null,
+    deletedBy: null,
+  });
+}
+
+export async function hideClientFieldDefinition(fieldId: string): Promise<void> {
+  await updateDoc(doc(getFirestoreDb(), COLLECTION_NAME, fieldId), {
+    hiddenFromManager: true,
+    updatedAt: serverTimestamp(),
+  });
+}

--- a/frontend/src/schema/clientSchema.ts
+++ b/frontend/src/schema/clientSchema.ts
@@ -4,6 +4,7 @@ import { nameRegex, nameError, CLIENT_STATUS, GENDER_OPTIONS, EDUCATION_STATUS_O
 import { medicalProfileSchema } from "./medicalSchema"
 import { contactSchema } from "./contactSchema"
 import { dependentSchema, logisticsSchema, questionnaireSchema, legalConsentsSchema } from "./supplementarySchema"
+import { customFieldsSchema } from "./customFieldSchema"
 
 // ============================================================================
 // Stays Schema
@@ -92,6 +93,7 @@ const clientBaseSchema = z.object({
   questionnaire: questionnaireSchema.optional().default({}),
   legal_consents: legalConsentsSchema.optional().default({}),
   stays: z.array(staySchema).default([]),
+  custom_fields: customFieldsSchema.optional().default({}),
 
   // Soft-delete flag
   is_archived: z.boolean().default(false).optional(),
@@ -138,7 +140,7 @@ export const basicInfoSchema = clientBaseSchema.pick({
   passport_id: true, gender: true, address: true, dob: true, referrer: true,
   education_status: true, program_ids: true, diagnosis: true, personal_notes: true,
   passport_number: true, passport_country: true, citizenship: true, home_address: true,
-  cohabitants: true, dependents: true,
+  cohabitants: true, dependents: true, custom_fields: true,
 });
 export type BasicInfoFormData = z.infer<typeof basicInfoSchema>;
 

--- a/frontend/src/schema/customFieldSchema.ts
+++ b/frontend/src/schema/customFieldSchema.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const CUSTOM_FIELD_TYPES = [
+  "text",
+  "textarea",
+  "number",
+  "date",
+  "select",
+  "checkbox",
+] as const;
+
+export const CUSTOM_FIELD_TABS = [
+  "profile",
+  "medical",
+  "contacts",
+  "logistics",
+  "questionnaire",
+  "legal_consents",
+  "documents",
+  "financial_aid",
+] as const;
+
+export const customFieldValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+]);
+
+export const customFieldsSchema = z.record(customFieldValueSchema).default({});
+
+export const clientFieldDefinitionSchema = z.object({
+  id: z.string(),
+  label: z.string().trim().min(1).max(80),
+  type: z.enum(CUSTOM_FIELD_TYPES),
+  tab: z.enum(CUSTOM_FIELD_TABS).default("profile"),
+  options: z.array(z.string().trim().min(1).max(80)).default([]),
+  isCustom: z.literal(true),
+  active: z.boolean(),
+  hiddenFromManager: z.boolean().optional().default(false),
+  createdBy: z.string(),
+  createdAt: z.unknown().optional(),
+  updatedAt: z.unknown().optional(),
+  deletedAt: z.unknown().nullable().optional(),
+  deletedBy: z.string().nullable().optional(),
+  order: z.number(),
+});
+
+export type CustomFieldType = (typeof CUSTOM_FIELD_TYPES)[number];
+export type CustomFieldTab = (typeof CUSTOM_FIELD_TABS)[number];
+export type CustomFieldValue = z.infer<typeof customFieldValueSchema>;
+export type CustomFields = z.infer<typeof customFieldsSchema>;
+export type ClientFieldDefinition = z.infer<typeof clientFieldDefinitionSchema>;


### PR DESCRIPTION
Implemented a custom fields management feature for client profiles. Admin users can add custom fields and assign them to specific client tabs, so each field appears only in the relevant section, such as Profile, Medical, Logistics, Documents, and more.

Custom field values are stored safely under each client’s custom_fields object, without changing or deleting existing system fields. The implementation also supports safe deactivation/reactivation of custom fields while preserving existing client data in Firestore.

The change includes schema updates, Firestore service logic, admin management UI, reusable custom field rendering, integration across client tabs, and updated Firestore rules.