### PR TITLE
fix: resolve tab render issue in admin and client pages

### DIFF
--- a/frontend/src/app/(client)/onboarding/page.tsx
+++ b/frontend/src/app/(client)/onboarding/page.tsx
@@ -9,6 +9,7 @@ import { doc, getDoc } from "firebase/firestore";
 import ClientDataForm from "@/components/clients/forms/ClientDataForm";
 import type { ClientDoc } from "@/components/clients/list/ClientList";
 import { auth, db } from "@/firebase/firebase";
+import { subscribeToClientDoc } from "@/firebase/clientDbService";
 import {
   ACCESS_DENIED_PATH,
   getAccountForUser,
@@ -66,10 +67,18 @@ export default function ClientOnboardingPage() {
     }
 
     let shouldIgnore = false;
+    let unsubscribeDoc: (() => void) | null = null;
     const activeAuth = auth;
     const activeDb = db;
 
-    const unsubscribe = onAuthStateChanged(activeAuth, async (user) => {
+    const unsubscribeAuth = onAuthStateChanged(activeAuth, async (user) => {
+      // Clean up any previous document listener when auth state changes
+      // (e.g. user logs out then back in, or hot-reload)
+      if (unsubscribeDoc) {
+        unsubscribeDoc();
+        unsubscribeDoc = null;
+      }
+
       if (!user) {
         router.replace("/login");
         return;
@@ -103,6 +112,9 @@ export default function ClientOnboardingPage() {
         }
 
         debugClientId = account.clientId;
+
+        // One-time guard read: verify the document exists and is not archived
+        // before starting the real-time listener.
         const clientSnapshot = await getDoc(
           doc(activeDb, "clients", account.clientId),
         );
@@ -122,16 +134,27 @@ export default function ClientOnboardingPage() {
           return;
         }
 
-        // The clientId comes from accounts/{uid}; Firestore rules then verify
-        // the same mapping before allowing this clients/{clientId} read.
-        setState({
-          status: "ready",
-          client: {
-            id: clientSnapshot.id,
-            ...clientSnapshot.data(),
-          } as ClientDoc,
-          message: "",
-        });
+        // Start the real-time listener — keeps state.client in sync after
+        // every tab save without threading callbacks through child components.
+        const unsub = subscribeToClientDoc(
+          account.clientId,
+          (client) => {
+            if (!shouldIgnore) {
+              setState({ status: "ready", client, message: "" });
+            }
+          },
+          (err) => {
+            if (!shouldIgnore) {
+              console.error("[ClientOnboarding] Document listener error:", err);
+            }
+          },
+        );
+
+        if (shouldIgnore) {
+          unsub();
+        } else {
+          unsubscribeDoc = unsub;
+        }
       } catch (error) {
         if (shouldIgnore) {
           return;
@@ -177,7 +200,10 @@ export default function ClientOnboardingPage() {
 
     return () => {
       shouldIgnore = true;
-      unsubscribe();
+      unsubscribeAuth();
+      if (unsubscribeDoc) {
+        unsubscribeDoc();
+      }
     };
   }, [isMounted, router]);
 

--- a/frontend/src/app/(protected)/clients/page.tsx
+++ b/frontend/src/app/(protected)/clients/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { exportToCSV } from "@/components/clients/list/csvExport";
 
 // TIER 1 - PRESENTATION LAYER WIDGETS
@@ -17,8 +17,7 @@ import { useClientManagementService } from "@/application/ClientManagementServic
 // TIER 3 - BUSINESS RULES LAYER
 import { useClientFilters } from "@/application/useClientFilters";
 import RestoreModal from "@/components/clients/list/RestoreModal";
-import { getFirestoreDb } from "@/firebase/clientDbService";
-import { doc, getDoc } from "firebase/firestore";
+
 
 type View = "list" | "form" | "dashboard";
 
@@ -31,7 +30,7 @@ type View = "list" | "form" | "dashboard";
 
 export default function ClientsPage() {
   const [view, setView] = useState<View>("list");
-  const [editingClient, setEditingClient] = useState<ClientDoc | null>(null);
+  const [editingClientId, setEditingClientId] = useState<string | null>(null);
   const [showArchived, setShowArchived] = useState(false);
   const [isFieldManagerOpen, setIsFieldManagerOpen] = useState(false);
 
@@ -44,6 +43,12 @@ export default function ClientsPage() {
   isRestoring, 
   handleRestore 
 } = useClientManagementService();
+
+  // Derive the live client from the real-time allDocs stream — never stale.
+  const editingClient = useMemo(
+    () => (editingClientId ? allDocs.find((c) => c.id === editingClientId) ?? null : null),
+    [editingClientId, allDocs],
+  );
 
   // Pass that data into the Business Rules Layer to get the filtered results
   // Business Rules Layer - Client Filtering & Sorting Policies
@@ -67,32 +72,21 @@ export default function ClientsPage() {
   */
 
   function handleAddNew() {
-    setEditingClient(null);
+    setEditingClientId(null);
     setView("form");
   }
 
   function handleEdit(client: ClientDoc) {
-    setEditingClient(client);
+    setEditingClientId(client.id);
     setView("dashboard");
   }
 
   function handleBackToList() {
-    setEditingClient(null);
+    setEditingClientId(null);
     setView("list");
   }
 
-  async function handleRefreshClient() {
-    if (!editingClient?.id) return;
-    try {
-      const db = getFirestoreDb();
-      const snap = await getDoc(doc(db, "clients", editingClient.id));
-      if (snap.exists()) {
-        setEditingClient({ id: snap.id, ...snap.data() } as ClientDoc);
-      }
-    } catch (err) {
-      console.error("Failed to refresh client data", err);
-    }
-  }
+
 // ─────────────────────────────────────────────────────────────────────────
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(220,234,214,0.72),_transparent_30%),linear-gradient(180deg,_#F7FAF5_0%,_#EEF5F7_100%)] px-4 py-8 sm:px-6 sm:py-10">
@@ -155,7 +149,6 @@ export default function ClientsPage() {
           <ClientProfileDashboard
             client={editingClient}
             onBack={handleBackToList}
-            onRefreshClient={handleRefreshClient}
           />
         )}
 

--- a/frontend/src/components/clients/dashboard/ClientProfileDashboard.tsx
+++ b/frontend/src/components/clients/dashboard/ClientProfileDashboard.tsx
@@ -25,7 +25,6 @@ import {
 interface ClientProfileDashboardProps {
   client: ClientDoc;
   onBack: () => void;
-  onRefreshClient?: () => void;
 }
 
 type AuthUserWithProfile = User & {
@@ -35,7 +34,7 @@ type AuthUserWithProfile = User & {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export default function ClientProfileDashboard({ client: initialClient, onBack, onRefreshClient }: ClientProfileDashboardProps) {
+export default function ClientProfileDashboard({ client: initialClient, onBack }: ClientProfileDashboardProps) {
   const [statusOverride, setStatusOverride] = useState<{
     clientId: string;
     status: ClientDoc["status"];
@@ -360,7 +359,6 @@ export default function ClientProfileDashboard({ client: initialClient, onBack, 
              client={client} 
              isArchived={isArchived} 
              onCreateMeeting={handleCreateMeetingNavigation} 
-             onClientUpdated={onRefreshClient}
           />
         )}
         {/* ── Advanced Settings ── */}

--- a/frontend/src/components/clients/dashboard/ClientProgramsWidget.tsx
+++ b/frontend/src/components/clients/dashboard/ClientProgramsWidget.tsx
@@ -14,8 +14,6 @@ interface ClientProgramsWidgetProps {
    * Defaults to `[]` so legacy client docs without this field don't crash.
    */
   programIds?: string[];
-  /** Callback to trigger parent component data refresh */
-  onClientUpdated?: () => void;
 }
 
 // ─── Inline SVG Icons ─────────────────────────────────────────────────────────
@@ -101,7 +99,6 @@ function IconGridSquares() {
 export default function ClientProgramsWidget({
   clientId,
   programIds = [],
-  onClientUpdated,
 }: ClientProgramsWidgetProps) {
   const { enrolledPrograms, availablePrograms, isLoading, error, assign, remove } =
     useClientPrograms(clientId, programIds);
@@ -145,9 +142,6 @@ export default function ClientProgramsWidget({
     await assign(selectedProgramId);
     setSelectedProgramId("");
     setIsAssigning(false);
-    if (onClientUpdated) {
-      onClientUpdated();
-    }
   };
 
   /** First click: enter confirming state. Does NOT trigger deletion yet. */
@@ -161,9 +155,6 @@ export default function ClientProgramsWidget({
     await remove(programId);
     if (selectedProgramId === programId) {
       setSelectedProgramId("");
-    }
-    if (onClientUpdated) {
-      onClientUpdated();
     }
   };
 

--- a/frontend/src/components/clients/dashboard/ProfileSummaryDashboard.tsx
+++ b/frontend/src/components/clients/dashboard/ProfileSummaryDashboard.tsx
@@ -21,7 +21,6 @@ interface ProfileSummaryDashboardProps {
   client: ClientDoc;
   isArchived: boolean;
   onCreateMeeting?: () => void; // We keep this for backward compatibility, but we won't use it for the button anymore
-  onClientUpdated?: () => void;
 }
 
 type AuthUserWithProfile = User & {
@@ -29,7 +28,7 @@ type AuthUserWithProfile = User & {
   last_name?: string;
 };
 
-export default function ProfileSummaryDashboard({ client, isArchived, onClientUpdated }: ProfileSummaryDashboardProps) {
+export default function ProfileSummaryDashboard({ client, isArchived }: ProfileSummaryDashboardProps) {
   // ── UI State (Tier 1) ────────────────────────────────────────────────────────
   const [isMeetingModalOpen, setIsMeetingModalOpen] = useState(false);
   const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
@@ -130,7 +129,6 @@ export default function ProfileSummaryDashboard({ client, isArchived, onClientUp
       setIsTrackArrivalModalOpen(false);
       setArrivalDate("");
       setTimelineRefreshKey((k) => k + 1);
-      onClientUpdated?.();
     } catch (err) {
       console.error(err);
     } finally {
@@ -158,7 +156,6 @@ export default function ProfileSummaryDashboard({ client, isArchived, onClientUp
       setIsTrackDepartureModalOpen(false);
       setDepartureDate("");
       setTimelineRefreshKey((k) => k + 1);
-      onClientUpdated?.();
     } catch (err) {
       console.error(err);
     } finally {
@@ -416,7 +413,6 @@ export default function ProfileSummaryDashboard({ client, isArchived, onClientUp
           clientId={client.id}
           programIds={client.program_ids ?? []}
           onClose={() => setIsProgramModalOpen(false)}
-          onClientUpdated={onClientUpdated}
         />
       )}
 
@@ -526,7 +522,6 @@ export default function ProfileSummaryDashboard({ client, isArchived, onClientUp
         onSuccess={() => {
           setIsStayHistoryModalOpen(false);
           setTimelineRefreshKey((k) => k + 1);
-          onClientUpdated?.();
         }}
       />
     </>

--- a/frontend/src/components/clients/dashboard/ProgramAssignmentModal.tsx
+++ b/frontend/src/components/clients/dashboard/ProgramAssignmentModal.tsx
@@ -6,7 +6,6 @@ interface ProgramAssignmentModalProps {
   clientId: string;
   programIds: string[];
   onClose: () => void;
-  onClientUpdated?: () => void;
 }
 
 /**
@@ -17,7 +16,6 @@ export default function ProgramAssignmentModal({
   clientId,
   programIds,
   onClose,
-  onClientUpdated,
 }: ProgramAssignmentModalProps) {
   return (
     <div
@@ -50,7 +48,6 @@ export default function ProgramAssignmentModal({
           <ClientProgramsWidget
             clientId={clientId}
             programIds={programIds}
-            onClientUpdated={onClientUpdated}
           />
         </div>
 

--- a/frontend/src/components/clients/tabs/controllers/ContactsTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/ContactsTabController.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
@@ -20,6 +20,18 @@ export const EMPTY_CONTACT: Contact = {
   is_emergency_contact: false,
 };
 
+function getContactsDefaultValues(client: ClientDoc): ContactsFormData {
+  return {
+    contacts: (client.contacts ?? []).map((c) => ({
+      contact_name: c.contact_name ?? "",
+      relationship: c.relationship ?? "",
+      phone: c.phone ?? "",
+      email: c.email ?? "",
+      is_emergency_contact: c.is_emergency_contact ?? false,
+    })),
+  };
+}
+
 /**
  * Tier 2: Application Controller for the Contacts Tab.
  * Manages form state, array validation, and database submissions.
@@ -34,16 +46,15 @@ export function useContactsTabController(client: ClientDoc) {
     // This ensures fields the user never touched are still caught when
     // the Save button is pressed on a card that was added but left blank.
     mode: "all",
-    defaultValues: {
-      contacts: (client.contacts ?? []).map((c) => ({
-        contact_name: c.contact_name ?? "",
-        relationship: c.relationship ?? "",
-        phone: c.phone ?? "",
-        email: c.email ?? "",
-        is_emergency_contact: c.is_emergency_contact ?? false,
-      })),
-    },
+    defaultValues: getContactsDefaultValues(client),
   });
+
+  // 1.5 Sync External Updates (from other tabs)
+  useEffect(() => {
+    if (!form.formState.isDirty) {
+      form.reset(getContactsDefaultValues(client));
+    }
+  }, [client, form, form.formState.isDirty]);
 
   // 2. Initialize Main Contacts Array
   const { fields, append, remove } = useFieldArray({

--- a/frontend/src/components/clients/tabs/controllers/DocumentsTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/DocumentsTabController.ts
@@ -29,8 +29,7 @@ const ACCEPTED_TYPES = [
  * Manages file validation, upload progress streams, and optimistic UI updates.
  */
 export function useDocumentsTabController(client: ClientDoc) {
-  // Local copy for optimistic UI updates (no page refresh needed)
-  const [docs, setDocs] = useState<ClientDocument[]>(client.client_documents ?? []);
+  const docs = client.client_documents ?? [];
   
   const [isLoading, setIsLoading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
@@ -92,15 +91,14 @@ export function useDocumentsTabController(client: ClientDoc) {
         manager_notes: formData.manager_notes ?? "",
       };
 
-      const updatedDocs = [...docs, newDoc];
+      const updatedDocs = [...(client.client_documents ?? []), newDoc];
 
       // Tier 2 calling Tier 4: Save Metadata to Firestore
       await updateClientDoc(client.id, {
         client_documents: updatedDocs,
       });
 
-      // Update local state & reset UI
-      setDocs(updatedDocs);
+      // Reset UI
       setSelectedFile(null);
       form.reset();
       toast.success(`"${file.name}" uploaded successfully.`);
@@ -111,23 +109,22 @@ export function useDocumentsTabController(client: ClientDoc) {
       setIsLoading(false);
       setUploadProgress(null);
     }
-  }, [client.id, docs, form, selectedFile]);
+  }, [client.id, client.client_documents, form, selectedFile]);
 
   // 4. Delete Handler (Bridges to Tier 4)
   const handleDelete = useCallback(async (index: number) => {
-    const updated = docs.filter((_, i) => i !== index);
+    const updated = (client.client_documents ?? []).filter((_, i) => i !== index);
     try {
       await updateClientDoc(client.id, {
         client_documents: updated,
       });
       
-      setDocs(updated);
       toast.success("Document removed.");
     } catch (err) {
       console.error("[DocumentsTabController] Delete failed:", err);
       toast.error("Could not remove the document. Please try again.");
     }
-  }, [client.id, docs]);
+  }, [client.id, client.client_documents]);
 
   // 5. Expose strictly what the UI Layer needs
   return {

--- a/frontend/src/components/clients/tabs/controllers/LegalConsentsTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/LegalConsentsTabController.ts
@@ -17,6 +17,22 @@ const legalConsentsTabSchema = z.object({
 });
 export type LegalConsentsTabFormData = z.infer<typeof legalConsentsTabSchema>;
 
+function getLegalConsentsDefaultValues(client: ClientDoc): LegalConsentsTabFormData {
+  const lc = client.legal_consents;
+  return {
+    legal_consents: {
+      release_authorizing_person: lc?.release_authorizing_person ?? "",
+      authorized_agencies:        (lc?.authorized_agencies ?? []).map((a) => a),
+      info_to_disclose:           lc?.info_to_disclose           ?? "",
+      release_reason:             lc?.release_reason             ?? "",
+      release_expiration_date:    lc?.release_expiration_date    ?? "",
+      release_expiration_event:   lc?.release_expiration_event   ?? "",
+      visit_waiver_child_name:    lc?.visit_waiver_child_name    ?? "",
+      visit_waiver_signatures:    (lc?.visit_waiver_signatures ?? []).map((s) => s),
+    },
+  };
+}
+
 /**
  * Tier 2: Application Controller for the Legal Consents Tab.
  * Manages form state, string arrays, validation side-effects, and DB saves.
@@ -29,25 +45,19 @@ export function useLegalConsentsTabController(client: ClientDoc) {
     setOpen((prev) => ({ ...prev, [key]: !prev[key] }));
   }
 
-  const lc = client.legal_consents;
-
   // 1. Initialize Form Engine
   const form = useForm<LegalConsentsTabFormData>({
     resolver: zodResolver(legalConsentsTabSchema),
     mode: "onTouched",
-    defaultValues: {
-      legal_consents: {
-        release_authorizing_person: lc?.release_authorizing_person ?? "",
-        authorized_agencies:        (lc?.authorized_agencies ?? []).map((a) => a),
-        info_to_disclose:           lc?.info_to_disclose           ?? "",
-        release_reason:             lc?.release_reason             ?? "",
-        release_expiration_date:    lc?.release_expiration_date    ?? "",
-        release_expiration_event:   lc?.release_expiration_event   ?? "",
-        visit_waiver_child_name:    lc?.visit_waiver_child_name    ?? "",
-        visit_waiver_signatures:    (lc?.visit_waiver_signatures ?? []).map((s) => s),
-      },
-    },
+    defaultValues: getLegalConsentsDefaultValues(client),
   });
+
+  // 1.5 Sync External Updates (from other tabs)
+  useEffect(() => {
+    if (!form.formState.isDirty) {
+      form.reset(getLegalConsentsDefaultValues(client));
+    }
+  }, [client, form, form.formState.isDirty]);
 
   // 2. Dynamic Arrays (React Hook Form requires 'as never' for primitive arrays)
   const agenciesArray = useFieldArray({

--- a/frontend/src/components/clients/tabs/controllers/MedicalTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/MedicalTabController.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "sonner";
@@ -72,14 +72,61 @@ function coerceMedications(raw: unknown): Medication[] {
   return [];
 }
 
+function getMedicalDefaultValues(client: ClientDoc): MedicalProfile {
+  const mp = client.medical_profile ?? {};
+  return {
+    // Seasickness Medications object
+    seasickness_meds: {
+      ...DEFAULT_SEASICKNESS_MEDS,
+      ...(mp as MedicalProfile).seasickness_meds,
+    },
+
+    // Dynamic arrays — coerced from either legacy string or new array shape
+    allergies:   coerceAllergies((mp as MedicalProfile).allergies),
+    medications: coerceMedications((mp as MedicalProfile).medications),
+    hospitalization_history: (mp.hospitalization_history ?? []).map((h) => ({
+      type: h.type ?? undefined,
+      date: h.date ?? "",
+      description: h.description ?? "",
+    })),
+    healthcare_providers: (mp.healthcare_providers ?? []).map((p) => ({
+      name: p.name ?? "", specialty: p.specialty ?? "", phone: p.phone ?? "",
+      email: p.email ?? "", facility: p.facility ?? "", last_appt: p.last_appt ?? "",
+    })),
+
+    // Hardcoded vaccination object
+    vaccination_history: {
+      ...DEFAULT_VACCINATION_HISTORY,
+      ...(mp as MedicalProfile).vaccination_history,
+    },
+
+    // Developmental history object
+    developmental_history: {
+      ...DEFAULT_DEVELOPMENTAL_HISTORY,
+      ...(mp as MedicalProfile).developmental_history,
+    },
+
+    // Past medical history
+    past_medical_history: {
+      ...DEFAULT_PAST_MEDICAL_HISTORY,
+      ...(mp as MedicalProfile).past_medical_history,
+    },
+
+    // Preserved free-text fields
+    dietary_restrictions:      mp.dietary_restrictions      ?? "",
+    psychiatric_history:       mp.psychiatric_history       ?? "",
+    treatment_history_details: (mp as MedicalProfile).treatment_history_details ?? "",
+    physical_accommodations:   (mp as MedicalProfile).physical_accommodations   ?? "",
+    general_accommodations:    (mp as MedicalProfile).general_accommodations    ?? "",
+  };
+}
+
 /**
  * Tier 2: Application Controller for the Medical Tab.
  * Manages field arrays, accordion state, and DB saves.
  */
 export function useMedicalTabController(client: ClientDoc) {
   const [isSaving, setIsSaving] = useState(false);
-
-  const mp = client.medical_profile ?? {};
 
   // 1. Accordion State
   const [open, setOpen] = useState({
@@ -102,52 +149,15 @@ export function useMedicalTabController(client: ClientDoc) {
   const form = useForm<MedicalProfile>({
     resolver: zodResolver(medicalProfileSchema),
     mode: "onTouched",
-    defaultValues: {
-      // Seasickness Medications object
-      seasickness_meds: {
-        ...DEFAULT_SEASICKNESS_MEDS,
-        ...(mp as MedicalProfile).seasickness_meds,
-      },
-
-      // Dynamic arrays — coerced from either legacy string or new array shape
-      allergies:   coerceAllergies((mp as MedicalProfile).allergies),
-      medications: coerceMedications((mp as MedicalProfile).medications),
-      hospitalization_history: (mp.hospitalization_history ?? []).map((h) => ({
-        type: h.type ?? undefined,
-        date: h.date ?? "",
-        description: h.description ?? "",
-      })),
-      healthcare_providers: (mp.healthcare_providers ?? []).map((p) => ({
-        name: p.name ?? "", specialty: p.specialty ?? "", phone: p.phone ?? "",
-        email: p.email ?? "", facility: p.facility ?? "", last_appt: p.last_appt ?? "",
-      })),
-
-      // Hardcoded vaccination object
-      vaccination_history: {
-        ...DEFAULT_VACCINATION_HISTORY,
-        ...(mp as MedicalProfile).vaccination_history,
-      },
-
-      // Developmental history object
-      developmental_history: {
-        ...DEFAULT_DEVELOPMENTAL_HISTORY,
-        ...(mp as MedicalProfile).developmental_history,
-      },
-
-      // Past medical history
-      past_medical_history: {
-        ...DEFAULT_PAST_MEDICAL_HISTORY,
-        ...(mp as MedicalProfile).past_medical_history,
-      },
-
-      // Preserved free-text fields
-      dietary_restrictions:      mp.dietary_restrictions      ?? "",
-      psychiatric_history:       mp.psychiatric_history       ?? "",
-      treatment_history_details: (mp as MedicalProfile).treatment_history_details ?? "",
-      physical_accommodations:   (mp as MedicalProfile).physical_accommodations   ?? "",
-      general_accommodations:    (mp as MedicalProfile).general_accommodations    ?? "",
-    },
+    defaultValues: getMedicalDefaultValues(client),
   });
+
+  // 2.5 Sync External Updates (from other tabs)
+  useEffect(() => {
+    if (!form.formState.isDirty) {
+      form.reset(getMedicalDefaultValues(client));
+    }
+  }, [client, form, form.formState.isDirty]);
 
   // 3. Field Arrays
   const providersArray = useFieldArray({ control: form.control, name: "healthcare_providers" });

--- a/frontend/src/components/clients/tabs/controllers/ProfileTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/ProfileTabController.ts
@@ -17,6 +17,35 @@ export const EMPTY_DEPENDENT: Dependent = {
   dob: "",
 };
 
+function getProfileDefaultValues(client: ClientDoc): BasicInfoFormData {
+  return {
+    first_name: client.first_name ?? "",
+    last_name: client.last_name ?? "",
+    email: client.email ?? "",
+    phone: client.phone ?? "",
+    status: client.status ?? "draft",
+    passport_id: client.passport_id ?? "",
+    gender: client.gender ?? undefined,
+    address: client.address ?? "",
+    dob: client.dob ?? "",
+    referrer: client.referrer ?? "",
+    education_status: client.education_status ?? undefined,
+    program_ids: client.program_ids ?? [],
+    diagnosis: client.diagnosis ?? "",
+    personal_notes: client.personal_notes ?? "",
+    passport_country: client.passport_country ?? "",
+    citizenship: client.citizenship ?? "",
+    home_address: client.home_address ?? "",
+    household_members: client.household_members ?? "",
+    dependents: (client.dependents ?? []).map((d) => ({
+      name: d.name ?? "",
+      relationship: d.relationship ?? "",
+      dob: d.dob ?? "",
+    })),
+    custom_fields: client.custom_fields ?? {},
+  };
+}
+
 /**
  * Tier 2: Application Controller for the Profile Tab.
  * Manages all form state, validation side-effects, and database submissions.
@@ -33,35 +62,17 @@ export function useProfileTabController(client: ClientDoc) {
   const form = useForm<BasicInfoFormData>({
     resolver: zodResolver(basicInfoSchema),
     mode: "onTouched",
-    defaultValues: {
-      first_name: client.first_name ?? "",
-      last_name: client.last_name ?? "",
-      email: client.email ?? "",
-      phone: client.phone ?? "",
-      status: client.status ?? "draft",
-      passport_id: client.passport_id ?? "",
-      gender: client.gender ?? undefined,
-      address: client.address ?? "",
-      dob: client.dob ?? "",
-      referrer: client.referrer ?? "",
-      education_status: client.education_status ?? undefined,
-      program_ids: client.program_ids ?? [],
-      diagnosis: client.diagnosis ?? "",
-      personal_notes: client.personal_notes ?? "",
-      passport_country: client.passport_country ?? "",
-      citizenship: client.citizenship ?? "",
-      home_address: client.home_address ?? "",
-      household_members: client.household_members ?? "",
-      dependents: (client.dependents ?? []).map((d) => ({
-        name: d.name ?? "",
-        relationship: d.relationship ?? "",
-        dob: d.dob ?? "",
-      })),
-      custom_fields: client.custom_fields ?? {},
-    },
+    defaultValues: getProfileDefaultValues(client),
   });
 
-  // 2. Initialize Field Arrays
+  // 2. Sync External Updates (from other tabs)
+  useEffect(() => {
+    if (!form.formState.isDirty) {
+      form.reset(getProfileDefaultValues(client));
+    }
+  }, [client, form, form.formState.isDirty]);
+
+  // 3. Initialize Field Arrays
   const {
     fields: dependentFields,
     append: appendDependent,
@@ -73,7 +84,7 @@ export function useProfileTabController(client: ClientDoc) {
 
   const { errors } = form.formState;
 
-  // 3. Error Listeners (Auto-open accordions if a field fails validation)
+  // 4. Error Listeners (Auto-open accordions if a field fails validation)
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (errors.first_name || errors.last_name || errors.email || errors.phone || errors.status) {
@@ -100,7 +111,7 @@ export function useProfileTabController(client: ClientDoc) {
     errors.diagnosis, errors.personal_notes, errors.dependents,
   ]);
 
-  // 4. Save Handler (Bridges to Tier 4)
+  // 5. Save Handler (Bridges to Tier 4)
   async function onSubmit(data: BasicInfoFormData) {
     setIsSaving(true);
     try {
@@ -122,7 +133,7 @@ export function useProfileTabController(client: ClientDoc) {
     }
   }
 
-  // 5. Expose strictly what the UI Layer needs
+  // 6. Expose strictly what the UI Layer needs
   return {
     form,
     dependents: {

--- a/frontend/src/components/clients/tabs/controllers/QuestionnaireTabController.ts
+++ b/frontend/src/components/clients/tabs/controllers/QuestionnaireTabController.ts
@@ -17,6 +17,25 @@ const questionnaireTabSchema = z.object({
 });
 export type QuestionnaireTabFormData = z.infer<typeof questionnaireTabSchema>;
 
+function getQuestionnaireDefaultValues(client: ClientDoc): QuestionnaireTabFormData {
+  return {
+    questionnaire: {
+      talents_and_skills:     client.questionnaire?.talents_and_skills     ?? "",
+      community_contribution: client.questionnaire?.community_contribution ?? "",
+      ideal_roommate:         client.questionnaire?.ideal_roommate         ?? "",
+      favorite_foods:         client.questionnaire?.favorite_foods         ?? "",
+      desired_activities:     client.questionnaire?.desired_activities     ?? "",
+      program_worries:        client.questionnaire?.program_worries        ?? "",
+      main_goals:             client.questionnaire?.main_goals             ?? "",
+      personal_challenge:     client.questionnaire?.personal_challenge     ?? "",
+      staff_assistance:       client.questionnaire?.staff_assistance       ?? "",
+      main_strengths:         client.questionnaire?.main_strengths         ?? "",
+      passions:               client.questionnaire?.passions               ?? "",
+      dream_jobs:             client.questionnaire?.dream_jobs             ?? "",
+    },
+  };
+}
+
 /**
  * Tier 2: Application Controller for the Questionnaire Tab.
  * Manages form state, validation side-effects, and database submissions.
@@ -33,23 +52,15 @@ export function useQuestionnaireTabController(client: ClientDoc) {
   const form = useForm<QuestionnaireTabFormData>({
     resolver: zodResolver(questionnaireTabSchema),
     mode: "onTouched",
-    defaultValues: {
-      questionnaire: {
-        talents_and_skills:     client.questionnaire?.talents_and_skills     ?? "",
-        community_contribution: client.questionnaire?.community_contribution ?? "",
-        ideal_roommate:         client.questionnaire?.ideal_roommate         ?? "",
-        favorite_foods:         client.questionnaire?.favorite_foods         ?? "",
-        desired_activities:     client.questionnaire?.desired_activities     ?? "",
-        program_worries:        client.questionnaire?.program_worries        ?? "",
-        main_goals:             client.questionnaire?.main_goals             ?? "",
-        personal_challenge:     client.questionnaire?.personal_challenge     ?? "",
-        staff_assistance:       client.questionnaire?.staff_assistance       ?? "",
-        main_strengths:         client.questionnaire?.main_strengths         ?? "",
-        passions:               client.questionnaire?.passions               ?? "",
-        dream_jobs:             client.questionnaire?.dream_jobs             ?? "",
-      },
-    },
+    defaultValues: getQuestionnaireDefaultValues(client),
   });
+
+  // 1.5 Sync External Updates (from other tabs)
+  useEffect(() => {
+    if (!form.formState.isDirty) {
+      form.reset(getQuestionnaireDefaultValues(client));
+    }
+  }, [client, form, form.formState.isDirty]);
 
   const { errors } = form.formState;
   const qe = errors.questionnaire;

--- a/frontend/src/firebase/clientDbService.ts
+++ b/frontend/src/firebase/clientDbService.ts
@@ -315,6 +315,29 @@ export function subscribeToClients(
 }
 
 /**
+ * Subscribes to a single client document and fires callbacks on data changes.
+ * Designed for the client-facing portal where only one document is relevant.
+ * Returns the unsubscribe function to clean up the listener.
+ */
+export function subscribeToClientDoc(
+  clientId: string,
+  onData: (client: ClientDoc) => void,
+  onError: (error: Error) => void
+) {
+  const docRef = doc(getFirestoreDb(), "clients", clientId);
+
+  return onSnapshot(
+    docRef,
+    (snapshot) => {
+      if (snapshot.exists()) {
+        onData({ id: snapshot.id, ...snapshot.data() } as ClientDoc);
+      }
+    },
+    (err) => onError(err)
+  );
+}
+
+/**
  * Uploads a client document to Firebase Storage and reports progress.
  * Returns the final download URL.
  */


### PR DESCRIPTION
### Client Page (onboarding/page.tsx)
- Switched the data retrieval from a single read to an active database listener.
- Added cleanup logic to disconnect the database listener when the user leaves the page.
- Added an unmount check to prevent state updates if the page closes before the connection finishes loading.

#### Admin Page (clients/page.tsx)
- Removed the separate state copy of the selected client.
- Set the page to read the client data directly from the active master list.
- Deleted the manual data-refresh triggers.

### Tab Controllers
- Configured the forms to update automatically when the database information changes.
- Added a condition to skip the form update if the user is currently editing fields.
- Removed local state management for the documents array.
- Deleted unused setup variables.